### PR TITLE
Limit accessibility controls to settings and fix API fallback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,6 @@ import Settings from '@/components/dashboard/Settings.jsx'; // Import the Settin
 import ClosedAlphaGate from '@/components/ClosedAlphaGate.jsx';
 import { Toaster } from '@/components/ui/toaster.jsx';
 import MetaHead from '@/components/MetaHead.jsx';
-import ComfortMenu from '@/components/common/ComfortMenu.jsx';
 import TermsGate from '@/components/common/TermsGate.jsx';
 
 // --- IMPORTANT ---
@@ -178,7 +177,6 @@ export default function App() {
 export function AppWithToasterWrapper() {
     return <>
     <MetaHead />
-    <ComfortMenu />
         <App />
         <Toaster />
     </>;

--- a/frontend/src/components/common/ComfortMenu.jsx
+++ b/frontend/src/components/common/ComfortMenu.jsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { useComfort } from '@/ComfortContext.jsx';
 
-export default function ComfortMenu() {
+export default function ComfortMenu({ inline = false, className = '' }) {
   const { largeText, setLargeText, highContrast, setHighContrast } = useComfort();
   const [open, setOpen] = useState(false);
   const panelId = useId();
@@ -13,16 +13,55 @@ export default function ComfortMenu() {
   const contrastId = useId();
 
   useEffect(() => {
-    if (!open) return;
+    if (inline || !open) return;
     const onKey = (event) => {
       if (event.key === 'Escape') setOpen(false);
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [open]);
+  }, [open, inline]);
+
+  const settingsContent = (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor={largeId} className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+            <Type className="h-3.5 w-3.5" aria-hidden="true" /> Larger text
+          </Label>
+          <p id={`${largeId}-hint`} className="text-[11px] text-muted-foreground">Boosts base font size for easier reading.</p>
+        </div>
+        <Switch id={largeId} checked={largeText} onCheckedChange={setLargeText} aria-describedby={`${largeId}-hint`} />
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor={contrastId} className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+            <Contrast className="h-3.5 w-3.5" aria-hidden="true" /> High contrast
+          </Label>
+          <p id={`${contrastId}-hint`} className="text-[11px] text-muted-foreground">Enhances color contrast and underlines links.</p>
+        </div>
+        <Switch id={contrastId} checked={highContrast} onCheckedChange={setHighContrast} aria-describedby={`${contrastId}-hint`} />
+      </div>
+    </div>
+  );
+
+  if (inline) {
+    const containerClasses = ['rounded-md border bg-white p-4 shadow-sm'];
+    if (className) containerClasses.push(className);
+    return (
+      <div className={containerClasses.join(' ')}>
+        <div className="flex items-center justify-between pb-2">
+          <div className="flex items-center gap-2">
+            <Accessibility className="h-4 w-4 text-primary" aria-hidden="true" />
+            <p className="text-sm font-semibold">Display options</p>
+          </div>
+        </div>
+        {settingsContent}
+      </div>
+    );
+  }
 
   return (
-    <div className="fixed top-4 right-4 z-50 flex flex-col items-end gap-2 text-sm">
+    <div className={`fixed top-4 right-4 z-50 flex flex-col items-end gap-2 text-sm${className ? ` ${className}` : ''}`}>
       <div
         id={panelId}
         className={`w-64 rounded-md border bg-white p-4 shadow-lg transition-all ${open ? 'opacity-100 visible translate-y-0' : 'pointer-events-none invisible -translate-y-2 opacity-0'}`}
@@ -37,26 +76,7 @@ export default function ComfortMenu() {
             <X className="h-4 w-4" />
           </Button>
         </div>
-        <div className="space-y-3">
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <Label htmlFor={largeId} className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
-                <Type className="h-3.5 w-3.5" aria-hidden="true" /> Larger text
-              </Label>
-              <p id={`${largeId}-hint`} className="text-[11px] text-muted-foreground">Boosts base font size for easier reading.</p>
-            </div>
-            <Switch id={largeId} checked={largeText} onCheckedChange={setLargeText} aria-describedby={`${largeId}-hint`} />
-          </div>
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-1">
-              <Label htmlFor={contrastId} className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
-                <Contrast className="h-3.5 w-3.5" aria-hidden="true" /> High contrast
-              </Label>
-              <p id={`${contrastId}-hint`} className="text-[11px] text-muted-foreground">Enhances color contrast and underlines links.</p>
-            </div>
-            <Switch id={contrastId} checked={highContrast} onCheckedChange={setHighContrast} aria-describedby={`${contrastId}-hint`} />
-          </div>
-        </div>
+        {settingsContent}
       </div>
       <Button
         variant={open ? 'secondary' : 'outline'}

--- a/frontend/src/components/dashboard/Settings.jsx
+++ b/frontend/src/components/dashboard/Settings.jsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import AudioCleanupSettings from "@/components/dashboard/AudioCleanupSettings";
 import AdminSettings from "@/components/dashboard/AdminSettings";
+import ComfortMenu from "@/components/common/ComfortMenu.jsx";
 import { useToast } from "@/hooks/use-toast";
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useAuth } from "@/AuthContext.jsx";
@@ -137,6 +138,11 @@ export default function Settings({ token }) {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
+            <div>
+              <h3 className="text-lg font-medium">Display preferences</h3>
+              <p className="text-sm text-muted-foreground mb-2">Adjust text size and contrast to make the workspace easier to use.</p>
+              <ComfortMenu inline className="mt-3" />
+            </div>
             <div>
               <h3 className="text-lg font-medium">Your profile</h3>
               <p className="text-sm text-muted-foreground mb-2">We’ll use this to say hello and label your work.</p>

--- a/frontend/src/components/landing-page.jsx
+++ b/frontend/src/components/landing-page.jsx
@@ -31,9 +31,13 @@ const runtimeApiBase = (() => {
   const env = import.meta.env?.VITE_API_BASE || import.meta.env?.VITE_API_BASE_URL;
   if (env && typeof env === "string") return env.replace(/\/+$/, "");
   if (typeof window !== "undefined") {
-    const origin = window.location.origin;
-    if (origin.includes("app.")) return origin.replace("app.", "api.");
-    return origin;
+    let origin = window.location.origin;
+    if (origin.includes("app.")) {
+      origin = origin.replace("app.", "api.");
+    } else if (origin.includes("dashboard.")) {
+      origin = origin.replace("dashboard.", "api.");
+    }
+    return origin.replace(/\/+$/, "");
   }
   return "";
 })();

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -12,6 +12,8 @@ const runtimeBase = (() => {
     let origin = window.location.origin;
     if (origin.includes('app.')) {
       origin = origin.replace('app.', 'api.');
+    } else if (origin.includes('dashboard.')) {
+      origin = origin.replace('dashboard.', 'api.');
     }
     return origin.replace(/\/+$/, '');
   }


### PR DESCRIPTION
## Summary
- remove the floating accessibility display button from the global app wrapper
- reuse the ComfortMenu component inline on the dashboard settings page so users can adjust text and contrast there
- extend API base URL fallbacks to support the dashboard.* host for login and terms requests

## Testing
- `npm --prefix frontend run test -- --run` *(fails: vitest expects src/tests/setupTests.ts which is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d01a9b69408320b618b5a6a95f024a