### PR TITLE
Fix missing UserTermsAcceptance import in CRUD module

### DIFF
--- a/podcast-pro-plus/api/core/crud.py
+++ b/podcast-pro-plus/api/core/crud.py
@@ -4,7 +4,7 @@ from uuid import UUID
 import json
 
 from .security import get_password_hash
-from ..models.user import User, UserCreate, UserPublic
+from ..models.user import User, UserCreate, UserPublic, UserTermsAcceptance
 from ..models.podcast import Podcast, PodcastTemplate, PodcastTemplateCreate, Episode, EpisodeStatus
 from ..models.subscription import Subscription
 


### PR DESCRIPTION
## Summary
- include UserTermsAcceptance in the CRUD module imports so routers depending on api.core.crud can be imported during startup

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_e_68d06b0c3120832083d1f7a6c529d001