### PR TITLE
Fix billing usage endpoint SQL function import

### DIFF
--- a/podcast-pro-plus/api/routers/billing.py
+++ b/podcast-pro-plus/api/routers/billing.py
@@ -11,6 +11,7 @@ from ..core.constants import TIER_LIMITS
 from ..core import crud
 from uuid import UUID
 from sqlmodel import select
+from sqlalchemy import func
 from ..services.billing import usage as usage_svc
 from ..core.config import settings
 


### PR DESCRIPTION
## Summary
- import sqlalchemy.func in the billing router so the usage endpoint can count episodes without raising a NameError
- ensure the billing usage API responds successfully, allowing CORS middleware to attach the required headers again

## Testing
- pytest tests/test_minutes_ledger.py


------
https://chatgpt.com/codex/tasks/task_e_68d1d2f8037483208e8211ef501e4eff