### PR TITLE
Add contextual guides across onboarding and creator workflows

### DIFF
--- a/frontend/src/components/dashboard/TemplateEditor.jsx
+++ b/frontend/src/components/dashboard/TemplateEditor.jsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+import Joyride, { EVENTS, STATUS } from "react-joyride";
 import TemplateAIContent from "./TemplateAIContent";
 import {
     Plus,
@@ -20,8 +21,11 @@ import {
   Bot,
   Settings2,
   HelpCircle,
+  Lightbulb,
+  ListChecks,
+  Compass,
 } from "lucide-react";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { makeApi } from "@/lib/apiClient";
 import { createTTS } from "@/api/media";
 import { toast } from "@/hooks/use-toast";
@@ -90,6 +94,7 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
     const [ttsLoading, setTtsLoading] = useState(false);
     const [createdFromTTS, setCreatedFromTTS] = useState({}); // { segmentId: timestampMs }
     const [showAdvanced, setShowAdvanced] = useState(false);
+    const [runTemplateTour, setRunTemplateTour] = useState(false);
 
         // Load voices when TTS modal opens
         useEffect(() => {
@@ -402,8 +407,72 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
 
   const hasContentSegment = template.segments.some(s => s.segment_type === 'content');
 
+  const templateTourSteps = useMemo(() => [
+    {
+      target: '[data-tour="template-quickstart"]',
+      title: 'Template overview',
+      content: 'We will walk through the three key tasks: link a show, build your segment flow, and fine-tune timing before saving.',
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="template-basics"]',
+      title: 'Start with the basics',
+      content: podcasts.length === 0
+        ? 'Create a show first so you can attach this template. Once a show exists, you will unlock publishing options here.'
+        : 'Give the template a clear name and connect it to the show it belongs to. That ensures new episodes pick up the right defaults.',
+    },
+    {
+      target: '[data-tour="template-add"]',
+      title: 'Add your building blocks',
+      content: 'Use these buttons to add intro, content, outro, or ad segments. You can always drag to reorder later.',
+    },
+    {
+      target: '[data-tour="template-structure"]',
+      title: 'Customize each segment',
+      content: hasContentSegment
+        ? 'Edit scripts, upload clips, and adjust voices right inside this list. Drag handles let you reorder in seconds.'
+        : 'Drop in a Content segment so you can drag your uploaded audio into the right spot, then adjust intros, outros, and ads here.',
+    },
+    {
+      target: '[data-tour="template-advanced"]',
+      title: 'Fine-tune timing & music',
+      content: 'Advanced controls handle crossfades, background music rules, and AI defaults. Open this panel whenever you need detailed tweaks.',
+    },
+    {
+      target: '[data-tour="template-save"]',
+      title: 'Save & reuse',
+      content: 'When everything looks right, save the template. New episodes will use these defaults automatically.',
+    },
+  ], [podcasts.length, hasContentSegment]);
+
+  const handleTourCallback = useCallback((data) => {
+    const { status, type, step } = data;
+    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+      setRunTemplateTour(false);
+      return;
+    }
+    if (type === EVENTS.TARGET_NOT_FOUND) {
+      setRunTemplateTour(false);
+      return;
+    }
+    if (type === EVENTS.STEP_BEFORE && step?.target === '[data-tour="template-advanced"]') {
+      setShowAdvanced(true);
+    }
+  }, [setRunTemplateTour, setShowAdvanced]);
+
   return (
     <div className="p-6 bg-gray-50 min-h-screen space-y-6">
+        <Joyride
+            steps={templateTourSteps}
+            run={runTemplateTour}
+            continuous
+            showSkipButton
+            scrollToFirstStep
+            disableOverlayClose
+            callback={handleTourCallback}
+            styles={{ options: { zIndex: 10000 } }}
+            spotlightClicks
+        />
         <div className="flex justify-between items-center">
             <Button onClick={handleBackClick} variant="ghost" className="text-gray-700"><ArrowLeft className="w-4 h-4 mr-2" />Back</Button>
             <h1 className="text-2xl font-bold text-gray-800">Template Editor</h1>
@@ -415,7 +484,39 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
             </div>
         </div>
 
-                <Card className="shadow-sm">
+                <Card className="border border-slate-200 bg-slate-50" data-tour="template-quickstart">
+                    <CardHeader className="flex flex-col gap-1 pb-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-2 text-slate-800">
+                            <Compass className="h-5 w-5 text-primary" aria-hidden="true" />
+                            <CardTitle className="text-base">Template quickstart</CardTitle>
+                        </div>
+                        <CardDescription className="text-sm text-slate-600 sm:text-right">
+                            Three checkpoints to get from blank template to publish-ready episodes.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm text-slate-700">
+                        <ol className="list-decimal space-y-1 pl-5">
+                            <li>Name the template and attach it to the show it powers.</li>
+                            <li>Add intro, content, and outro segments—drag to match your flow.</li>
+                            <li>Open Advanced options to dial in timing, music, and AI defaults.</li>
+                        </ol>
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <span className="text-xs text-slate-500">Prefer a tour? We’ll highlight each area for you.</span>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                    setShowAdvanced(false);
+                                    setRunTemplateTour(true);
+                                }}
+                            >
+                                Start guided tour
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="shadow-sm" data-tour="template-status">
                     <CardContent className="p-6 flex items-center justify-between">
                         <div>
                             <CardTitle className="text-lg">Template status</CardTitle>
@@ -432,7 +533,7 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
                     </CardContent>
                 </Card>
 
-                <Card className="shadow-sm"><CardContent className="p-6 space-y-6">
+                <Card className="shadow-sm" data-tour="template-basics"><CardContent className="p-6 space-y-6">
                         <div>
                             <Label htmlFor="template-name" className="text-sm font-medium text-gray-600">Template Name</Label>
                             <Input id="template-name" className="text-2xl font-bold border-0 border-b-2 border-gray-200 focus:border-blue-500 transition-colors p-0" value={template.name || ''} onChange={(e) => handleTemplateChange('name', e.target.value)} />
@@ -469,14 +570,14 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
                     </CardContent>
                 </Card>
 
-        <Card><CardHeader><CardTitle>Add Segments</CardTitle><CardDescription>Add the building blocks for your episode.</CardDescription></CardHeader><CardContent className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card data-tour="template-add"><CardHeader><CardTitle>Add Segments</CardTitle><CardDescription>Add the building blocks for your episode.</CardDescription></CardHeader><CardContent className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <AddSegmentButton type="intro" onClick={addSegment} />
             <AddSegmentButton type="content" onClick={addSegment} disabled={hasContentSegment} />
             <AddSegmentButton type="outro" onClick={addSegment} />
             <AddSegmentButton type="commercial" onClick={addSegment} />
         </CardContent></Card>
 
-        <Card><CardHeader><CardTitle>Episode Structure</CardTitle><CardDescription>Drag and drop segments to reorder them.</CardDescription></CardHeader><CardContent>
+        <Card data-tour="template-structure"><CardHeader><CardTitle>Episode Structure</CardTitle><CardDescription>Drag and drop segments to reorder them.</CardDescription></CardHeader><CardContent>
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="segments">
                     {(provided) => (
@@ -528,116 +629,145 @@ export default function TemplateEditor({ templateId, onBack, token, onTemplateSa
             </Button>
         </div>
         {showAdvanced && (
-            <>
-                <Card>
+            <div className="grid gap-6 lg:grid-cols-[2fr_1fr]" data-tour="template-advanced">
+                <div className="space-y-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2"><Settings2 className="w-6 h-6 text-gray-600" /> Advanced Settings</CardTitle>
+                            <CardDescription>Fine-tune the timing and background music for your podcast.</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-6 pt-4">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                <div>
+                                    <Label className="flex items-center gap-1">
+                                        Content Start Delay (seconds)
+                                        <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" title="Delay before main content begins after intro. Use negatives to overlap." />
+                                    </Label>
+                                    <Input type="number" step="0.5" value={template.timing?.content_start_offset_s} onChange={(e) => handleTimingChange('content_start_offset_s', parseFloat(e.target.value || 0))} />
+                                    <p className="text-xs text-gray-500 mt-1">Delay / overlap (negative overlaps intro). Default 0.</p>
+                                </div>
+                                <div>
+                                    <Label className="flex items-center gap-1">
+                                        Outro Start Delay (seconds)
+                                        <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" title="Delay before the outro begins. Use negatives to overlap." />
+                                    </Label>
+                                    <Input type="number" step="0.5" value={template.timing?.outro_start_offset_s} onChange={(e) => handleTimingChange('outro_start_offset_s', parseFloat(e.target.value || 0))} />
+                                    <p className="text-xs text-gray-500 mt-1">Delay / overlap (negative overlaps content tail). Default 0.</p>
+                                </div>
+                            </div>
+                            <div>
+                                <h4 className="text-lg font-semibold mb-2 flex items-center gap-1">
+                                    Background Music
+                                    <HelpCircle className="h-4 w-4 text-muted-foreground" aria-hidden="true" title="Apply looping music or stingers to specific sections." />
+                                </h4>
+                                <div className="space-y-4">
+                                    {(template.background_music_rules || []).map((rule, index) => (
+                                        <div key={rule.id} className="p-4 border rounded-lg bg-gray-50 space-y-4">
+                                            <div className="flex justify-between items-center">
+                                                <Label className="font-semibold">Music Rule #{index + 1}</Label>
+                                                <Button variant="destructive" size="sm" onClick={() => removeBackgroundMusicRule(index)}>
+                                                    <Trash2 className="w-4 h-4 mr-2" />Remove
+                                                </Button>
+                                            </div>
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                <div>
+                                                    <Label>Apply to Section</Label>
+                                                    <Select value={rule.apply_to_segments[0]} onValueChange={(v) => handleBackgroundMusicChange(index, 'apply_to_segments', [v])}>
+                                                        <SelectTrigger><SelectValue /></SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="intro">Intro Section</SelectItem>
+                                                            <SelectItem value="content">Content Section</SelectItem>
+                                                            <SelectItem value="outro">Outro Section</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                </div>
+                                                <div>
+                                                    <Label>Music File</Label>
+                                                    <Select value={rule.music_filename} onValueChange={(v) => handleBackgroundMusicChange(index, 'music_filename', v)}>
+                                                        <SelectTrigger><SelectValue placeholder="Select music..." /></SelectTrigger>
+                                                        <SelectContent>{musicFiles.map(f => <SelectItem key={f.id} value={f.filename}>{f.friendly_name || f.filename.split('_').slice(1).join('_')}</SelectItem>)}</SelectContent>
+                                                    </Select>
+                                                </div>
+                                            </div>
+                                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                                                <div>
+                                                    <Label>Start Offset (sec)</Label>
+                                                    <Input type="number" step="0.5" value={rule.start_offset_s} onChange={(e) => handleBackgroundMusicChange(index, 'start_offset_s', parseFloat(e.target.value || 0))} />
+                                                </div>
+                                                <div>
+                                                    <Label>End Offset (sec)</Label>
+                                                    <Input type="number" step="0.5" value={rule.end_offset_s} onChange={(e) => handleBackgroundMusicChange(index, 'end_offset_s', parseFloat(e.target.value || 0))} />
+                                                </div>
+                                                <div>
+                                                    <Label>Fade In (sec)</Label>
+                                                    <Input type="number" step="0.5" value={rule.fade_in_s} onChange={(e) => handleBackgroundMusicChange(index, 'fade_in_s', parseFloat(e.target.value || 0))} />
+                                                </div>
+                                                <div>
+                                                    <Label>Fade Out (sec)</Label>
+                                                    <Input type="number" step="0.5" value={rule.fade_out_s} onChange={(e) => handleBackgroundMusicChange(index, 'fade_out_s', parseFloat(e.target.value || 0))} />
+                                                </div>
+                                            </div>
+                                            <div className="mt-4">
+                                                <Label>Volume (dB)</Label>
+                                                <div className="flex items-center gap-2">
+                                                    <Input
+                                                        type="range"
+                                                        min="-60"
+                                                        max="0"
+                                                        step="1"
+                                                        value={rule.volume_db}
+                                                        onChange={(e) => handleBackgroundMusicChange(index, 'volume_db', parseInt(e.target.value, 10))}
+                                                        className="w-full"
+                                                    />
+                                                    <span className="text-sm font-mono w-16 text-center">{rule.volume_db} dB</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                                <Button onClick={addBackgroundMusicRule} variant="outline" className="mt-4">
+                                    <Plus className="w-4 h-4 mr-2" />Add Music Rule
+                                </Button>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <TemplateAIContent
+                        value={(template?.ai_settings) || AI_DEFAULT}
+                        onChange={(next) => setTemplate(prev => ({ ...prev, ai_settings: next }))}
+                    />
+                </div>
+
+                <Card className="border border-slate-200 bg-slate-50 self-start">
                     <CardHeader>
-                        <CardTitle className="flex items-center gap-2"><Settings2 className="w-6 h-6 text-gray-600" /> Advanced Settings</CardTitle>
-                        <CardDescription>Fine-tune the timing and background music for your podcast.</CardDescription>
+                        <CardTitle className="text-base flex items-center gap-2 text-slate-800">
+                            <Lightbulb className="h-4 w-4 text-amber-500" aria-hidden="true" />
+                            Background music cheat sheet
+                        </CardTitle>
                     </CardHeader>
-                    <CardContent className="space-y-6 pt-4">
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <div>
-                                <Label className="flex items-center gap-1">
-                                    Content Start Delay (seconds)
-                                    <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" title="Delay before main content begins after intro. Use negatives to overlap." />
-                                </Label>
-                                <Input type="number" step="0.5" value={template.timing?.content_start_offset_s} onChange={(e) => handleTimingChange('content_start_offset_s', parseFloat(e.target.value || 0))} />
-                                <p className="text-xs text-gray-500 mt-1">Delay / overlap (negative overlaps intro). Default 0.</p>
-                            </div>
-                            <div>
-                                <Label className="flex items-center gap-1">
-                                    Outro Start Delay (seconds)
-                                    <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" title="Delay before the outro begins. Use negatives to overlap." />
-                                </Label>
-                                <Input type="number" step="0.5" value={template.timing?.outro_start_offset_s} onChange={(e) => handleTimingChange('outro_start_offset_s', parseFloat(e.target.value || 0))} />
-                                <p className="text-xs text-gray-500 mt-1">Delay / overlap (negative overlaps content tail). Default 0.</p>
-                            </div>
-                        </div>
-                        <div>
-                            <h4 className="text-lg font-semibold mb-2 flex items-center gap-1">
-                                Background Music
-                                <HelpCircle className="h-4 w-4 text-muted-foreground" aria-hidden="true" title="Apply looping music or stingers to specific sections." />
-                            </h4>
-                            <div className="space-y-4">
-                                {(template.background_music_rules || []).map((rule, index) => (
-                                    <div key={rule.id} className="p-4 border rounded-lg bg-gray-50 space-y-4">
-                                        <div className="flex justify-between items-center">
-                                            <Label className="font-semibold">Music Rule #{index + 1}</Label>
-                                            <Button variant="destructive" size="sm" onClick={() => removeBackgroundMusicRule(index)}>
-                                                <Trash2 className="w-4 h-4 mr-2" />Remove
-                                            </Button>
-                                        </div>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                            <div>
-                                                <Label>Apply to Section</Label>
-                                                <Select value={rule.apply_to_segments[0]} onValueChange={(v) => handleBackgroundMusicChange(index, 'apply_to_segments', [v])}>
-                                                    <SelectTrigger><SelectValue /></SelectTrigger>
-                                                    <SelectContent>
-                                                        <SelectItem value="intro">Intro Section</SelectItem>
-                                                        <SelectItem value="content">Content Section</SelectItem>
-                                                        <SelectItem value="outro">Outro Section</SelectItem>
-                                                    </SelectContent>
-                                                </Select>
-                                            </div>
-                                            <div>
-                                                <Label>Music File</Label>
-                                                <Select value={rule.music_filename} onValueChange={(v) => handleBackgroundMusicChange(index, 'music_filename', v)}>
-                                                    <SelectTrigger><SelectValue placeholder="Select music..." /></SelectTrigger>
-                                                    <SelectContent>{musicFiles.map(f => <SelectItem key={f.id} value={f.filename}>{f.friendly_name || f.filename.split('_').slice(1).join('_')}</SelectItem>)}</SelectContent>
-                                                </Select>
-                                            </div>
-                                        </div>
-                                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                                            <div>
-                                                <Label>Start Offset (sec)</Label>
-                                                <Input type="number" step="0.5" value={rule.start_offset_s} onChange={(e) => handleBackgroundMusicChange(index, 'start_offset_s', parseFloat(e.target.value || 0))} />
-                                            </div>
-                                            <div>
-                                                <Label>End Offset (sec)</Label>
-                                                <Input type="number" step="0.5" value={rule.end_offset_s} onChange={(e) => handleBackgroundMusicChange(index, 'end_offset_s', parseFloat(e.target.value || 0))} />
-                                            </div>
-                                            <div>
-                                                <Label>Fade In (sec)</Label>
-                                                <Input type="number" step="0.5" value={rule.fade_in_s} onChange={(e) => handleBackgroundMusicChange(index, 'fade_in_s', parseFloat(e.target.value || 0))} />
-                                            </div>
-                                            <div>
-                                                <Label>Fade Out (sec)</Label>
-                                                <Input type="number" step="0.5" value={rule.fade_out_s} onChange={(e) => handleBackgroundMusicChange(index, 'fade_out_s', parseFloat(e.target.value || 0))} />
-                                            </div>
-                                        </div>
-                                        <div className="mt-4">
-                                            <Label>Volume (dB)</Label>
-                                            <div className="flex items-center gap-2">
-                                                <Input
-                                                    type="range"
-                                                    min="-60"
-                                                    max="0"
-                                                    step="1"
-                                                    value={rule.volume_db}
-                                                    onChange={(e) => handleBackgroundMusicChange(index, 'volume_db', parseInt(e.target.value, 10))}
-                                                    className="w-full"
-                                                />
-                                                <span className="text-sm font-mono w-16 text-center">{rule.volume_db} dB</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-                            <Button onClick={addBackgroundMusicRule} variant="outline" className="mt-4">
-                                <Plus className="w-4 h-4 mr-2" />Add Music Rule
-                            </Button>
-                        </div>
+                    <CardContent className="space-y-3 text-sm text-slate-700">
+                        <p>Need a refresher on how the controls interact? Keep these guidelines in mind while you dial things in.</p>
+                        <ul className="space-y-2">
+                            <li className="flex items-start gap-2">
+                                <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+                                <span><strong>Offsets</strong> slide music earlier or later. Negative values create crossfades with the neighboring segment.</span>
+                            </li>
+                            <li className="flex items-start gap-2">
+                                <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+                                <span><strong>Fade in/out</strong> smooth the transitions. Longer fades work best for ambient tracks, shorter fades for stingers.</span>
+                            </li>
+                            <li className="flex items-start gap-2">
+                                <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+                                <span><strong>Volume</strong> is in dB. -12&nbsp;dB keeps music behind the voice, while -20&nbsp;dB is ideal for subtle underscoring.</span>
+                            </li>
+                        </ul>
+                        <p className="text-xs text-slate-500">Save when things sound right—your episode builder will inherit these timing rules.</p>
                     </CardContent>
                 </Card>
-
-                <TemplateAIContent
-                    value={(template?.ai_settings) || AI_DEFAULT}
-                    onChange={(next) => setTemplate(prev => ({ ...prev, ai_settings: next }))}
-                />
-            </>
+            </div>
         )}
-                <div className="flex justify-end items-center mt-6">
-            <Button onClick={handleSave} disabled={isSaving || !template.podcast_id || podcasts.length === 0} className="bg-blue-600 hover:bg-blue-700 text-white">
+        <div className="flex justify-end items-center mt-6">
+            <Button data-tour="template-save" onClick={handleSave} disabled={isSaving || !template.podcast_id || podcasts.length === 0} className="bg-blue-600 hover:bg-blue-700 text-white">
                 {isSaving ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving...</> : <><Save className="w-4 h-4 mr-2" />Save Template</>}
             </Button>
         </div>

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepCustomizeSegments.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepCustomizeSegments.jsx
@@ -3,7 +3,7 @@ import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Label } from '../../ui/label';
 import { Textarea } from '../../ui/textarea';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Lightbulb, ListChecks } from 'lucide-react';
 
 export default function StepCustomizeSegments({
   selectedTemplate,
@@ -73,6 +73,37 @@ export default function StepCustomizeSegments({
         <CardTitle style={{ color: '#2C3E50' }}>Step 3: Customize Your Episode</CardTitle>
         <p className="text-md text-gray-500 pt-2">Review the structure and fill in the required text for any AI-generated segments.</p>
       </CardHeader>
+      <Card className="border border-slate-200 bg-slate-50" data-tour-id="episode-segment-guide">
+        <CardHeader className="flex flex-col gap-1 pb-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-base flex items-center gap-2 text-slate-800">
+            <Lightbulb className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            How these segments play out
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-slate-700">
+          <p>
+            Each block below becomes a chapter in your final episode. Tweak the script, switch voices, or swap in uploaded
+            clips—changes are saved immediately.
+          </p>
+          <ul className="space-y-2">
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>Content</strong> anchors your uploaded audio. Intro/outro and ad slots wrap around it automatically.</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>TTS segments</strong> use the template’s default voice—edit the script here or tap “Change voice” for a different tone.</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>Static clips</strong> pull from your media library. Upload new stingers or music in the Template step if you need variety.</span>
+            </li>
+          </ul>
+          <p className="text-xs text-slate-500">
+            Pro tip: want to reuse this structure later? Save these updates back to the template once you love the flow.
+          </p>
+        </CardContent>
+      </Card>
       <Card className="border-0 shadow-lg bg-white">
         <CardContent className="p-6 space-y-4">
           {selectedTemplate && selectedTemplate.segments ? (

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Textarea } from '../../ui/textarea';
-import { ArrowLeft, Loader2, Wand2 } from 'lucide-react';
+import { ArrowLeft, Loader2, Wand2, Lightbulb, ListChecks } from 'lucide-react';
 
 export default function StepEpisodeDetails({
   episodeDetails,
@@ -36,6 +36,37 @@ export default function StepEpisodeDetails({
       <CardHeader className="text-center">
         <CardTitle style={{ color: '#2C3E50' }}>Step 5: Episode Details &amp; Scheduling</CardTitle>
       </CardHeader>
+      <Card className="border border-slate-200 bg-slate-50" data-tour-id="episode-details-guide">
+        <CardHeader className="flex flex-col gap-1 pb-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-base flex items-center gap-2 text-slate-800">
+            <Lightbulb className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            Publishing checklist
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-slate-700">
+          <p>
+            This is the last stop before you assemble or publish. Use it as a quick final review so you never miss a required
+            field.
+          </p>
+          <ul className="space-y-2">
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>Title &amp; description</strong>: keep keywords up front. Try the AI helpers for a punchy first draft.</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>Numbering &amp; tags</strong>: confirm season/episode numbers and add 3–5 tags so auto-generated show notes stay relevant.</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <ListChecks className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span><strong>Scheduling</strong>: choosing “Schedule” opens the calendar—pick a local date/time and we’ll convert it to UTC for you.</span>
+            </li>
+          </ul>
+          <p className="text-xs text-slate-500">
+            Need to brainstorm? The front-page guide has examples for titles, calls-to-action, and launch checklists.
+          </p>
+        </CardContent>
+      </Card>
       <Card className="border-0 shadow-lg bg-white">
         <CardContent className="p-6 space-y-6">
           <div className="grid md:grid-cols-2 gap-6">

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
-import { FileAudio, Loader2, Mic, Upload, ArrowLeft } from 'lucide-react';
+import { FileAudio, Loader2, Mic, Upload, ArrowLeft, Lightbulb } from 'lucide-react';
 
 // Inline intent questions were removed in favor of the floating modal.
 
@@ -57,6 +57,38 @@ export default function StepUploadAudio({
       <CardHeader className="text-center">
         <CardTitle style={{ color: '#2C3E50' }}>Step 2: Upload Main Content</CardTitle>
       </CardHeader>
+      <Card className="border border-slate-200 bg-slate-50" data-tour-id="episode-upload-guide">
+        <CardHeader className="flex flex-col gap-1 pb-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-base flex items-center gap-2 text-slate-800">
+            <Lightbulb className="h-4 w-4 text-amber-500" aria-hidden="true" />
+            Audio prep checklist
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-slate-700">
+          <p>
+            Give the automation a strong starting point with a clean, final mix. We’ll normalize levels on upload, but the
+            clearer the file the better the downstream edit.
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Use WAV or MP3 files under 200&nbsp;MB for the smoothest upload.</li>
+            <li>Trim long silences and keep background music subtle—we re-check loudness automatically.</li>
+            <li>Re-uploading? Drop the same filename and we’ll detect it so you can skip the wait.</li>
+          </ul>
+          <details className="rounded-lg border border-dashed border-slate-300 bg-white/80 p-3">
+            <summary className="cursor-pointer text-sm font-semibold text-slate-800">How intent questions work</summary>
+            <div className="mt-2 space-y-2 text-slate-600">
+              <p>
+                When we ask about episode intent or offers, those answers steer intro/outro copy, ad reads, and show notes.
+                Update them any time before you assemble.
+              </p>
+              <p>
+                Skip for now if you’re unsure—we’ll remind you before publishing and you can fill them in from Automations.
+              </p>
+            </div>
+          </details>
+        </CardContent>
+      </Card>
+
       <Card className="border-2 border-dashed border-gray-200 bg-white">
         <CardContent className="p-8">
           <div

--- a/frontend/src/components/onboarding/OnboardingWrapper.jsx
+++ b/frontend/src/components/onboarding/OnboardingWrapper.jsx
@@ -17,6 +17,8 @@ import {
   GitBranch,
   Repeat,
   CalendarDays,
+  Lightbulb,
+  ClipboardList,
 } from "lucide-react";
 import ComfortControls from "./ComfortControls.jsx";
 
@@ -88,26 +90,128 @@ export default function OnboardingWrapper({ steps, index, setIndex, onComplete, 
     const map = {
       welcome: HandHeart,
       showDetails: FileText,
-  format: FileText,
+      format: FileText,
       coverArt: ImageIcon,
-  introOutro: Sparkles,
-  music: Sparkles,
+      introOutro: Sparkles,
+      music: Sparkles,
       spreaker: Globe,
       elevenlabs: Sparkles,
-  publishDay: CheckCircle2,
-  finish: CheckCircle2,
-  rss: Globe,
-  analyze: FileText,
-  assets: ImageIcon,
-  // Added explicit icons for steps lacking one
-  yourName: User,
-  choosePath: GitBranch,
-  publishCadence: Repeat,
-  publishSchedule: CalendarDays,
-  ttsReview: Sparkles,
+      publishDay: CheckCircle2,
+      finish: CheckCircle2,
+      rss: Globe,
+      analyze: FileText,
+      assets: ImageIcon,
+      // Added explicit icons for steps lacking one
+      yourName: User,
+      choosePath: GitBranch,
+      publishCadence: Repeat,
+      publishSchedule: CalendarDays,
+      ttsReview: Sparkles,
     };
     return step?.id && map[step.id] ? map[step.id] : null;
   }, [step?.id]);
+
+  const guideScripts = useMemo(() => ({
+    welcome: {
+      headline: "What to expect",
+      summary: "You'll answer a few quick questions so we can pre-fill your show settings and connect the tools you already use.",
+      steps: [
+        "Have your show name, a short description, and any cover art handy.",
+        "If you're importing, keep the RSS URL nearby.",
+        "Prefer a walkthrough? Use the Guides button below to open the full getting started article.",
+      ],
+    },
+    yourName: {
+      headline: "Why we ask",
+      summary: "We personalize reminders and drafts using your first name only.",
+      steps: [
+        "Use the name you'd like to appear in emails and episode copy.",
+      ],
+    },
+    showDetails: {
+      headline: "Describe your show",
+      summary: "A clear name and description help us draft intros, titles, and marketing copy that sound like you.",
+      steps: [
+        "Aim for a 4+ character name that's easy to search.",
+        "Mention your audience and value proposition in the description.",
+        "You can tweak these later inside Show Settings.",
+      ],
+    },
+    format: {
+      headline: "Pick a starting format",
+      summary: "Formats determine which segments we auto-generate (intro, interview cues, outro, etc.).",
+      steps: [
+        "Choose the option that best matches your recurring structure—it's easy to adjust per episode.",
+        "Need something custom? Select the closest match and refine the template in the next step.",
+      ],
+    },
+    introOutro: {
+      headline: "Plan your openings",
+      summary: "Decide whether you want AI narration, an uploaded intro, or both.",
+      steps: [
+        "Upload any must-use clips so we can stitch them into every episode.",
+        "Prefer AI voiceovers? You'll preview voices in the ElevenLabs step.",
+      ],
+    },
+    music: {
+      headline: "Choose music rules",
+      summary: "Music rules control when theme tracks fade in or out across segments.",
+      steps: [
+        "Pick a library track now—we'll let you fine-tune timing inside the Template Editor.",
+        "Unsure? Select “Let CloudPod decide” and we'll recommend something calm to start.",
+      ],
+    },
+    elevenlabs: {
+      headline: "Preview voices",
+      summary: "Test a few AI voices and lock in the tone you want for narration or ad reads.",
+      steps: [
+        "Click preview to hear an example line.",
+        "Use the notes field to tell us about pronunciation or pacing preferences.",
+      ],
+    },
+    publishCadence: {
+      headline: "Set your cadence",
+      summary: "We use this to schedule reminders and auto-build episode timelines.",
+      steps: [
+        "Weekly cadence works best for most shows; bi-weekly expects every other week.",
+        "Not sure yet? Pick your best guess—you can change it any time.",
+      ],
+    },
+    publishSchedule: {
+      headline: "Pick preferred days",
+      summary: "Scheduling helps us plan drafts, reminders, and auto-publishing windows.",
+      steps: [
+        "Select the days you usually publish.",
+        "If you mark “I’m not sure,” we’ll pause scheduling nudges for now.",
+      ],
+    },
+    rss: {
+      headline: "Importing via RSS",
+      summary: "Drop your RSS feed URL and we'll pull recent episodes to learn your style.",
+      steps: [
+        "You can find the RSS link in Spotify for Podcasters, Apple Podcasts Connect, or your current host dashboard.",
+        "We'll never publish to that feed—this is read-only for setup.",
+      ],
+    },
+    spreaker: {
+      headline: "Connect Spreaker",
+      summary: "Connecting lets us publish directly for you without manual uploads.",
+      steps: [
+        "Have your Spreaker login ready; we only request episode-management scopes.",
+        "Prefer to skip? You can connect later in Integrations.",
+      ],
+    },
+    confirm: {
+      headline: "Review & finish",
+      summary: "Double-check the summary and continue—we'll start generating your workspace immediately.",
+      steps: [
+        "You can revisit any step later from Settings.",
+      ],
+    },
+  }), []);
+
+  const activeGuide = step?.id ? guideScripts[step.id] : null;
+  const StepGlyph = activeGuide?.icon || StepIcon;
 
   // Keyboard handling: Enter advances; Backspace won't navigate; Esc does nothing
   useEffect(() => {
@@ -319,6 +423,32 @@ export default function OnboardingWrapper({ steps, index, setIndex, onComplete, 
 
         {/* Right rail (1 col) */}
         <aside className="space-y-4">
+          {activeGuide && (
+            <Card data-tour-id="onboarding-dynamic-guide">
+              <CardHeader className="flex flex-row items-center gap-2 pb-2">
+                {(StepGlyph || Lightbulb) && (
+                  <div className="rounded-full bg-primary/10 p-2 text-primary">
+                    {StepGlyph ? <StepGlyph className="h-5 w-5" aria-hidden="true" /> : <Lightbulb className="h-5 w-5" aria-hidden="true" />}
+                  </div>
+                )}
+                <CardTitle className="text-base">{activeGuide.headline}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-muted-foreground">{activeGuide.summary}</p>
+                {Array.isArray(activeGuide.steps) && activeGuide.steps.length > 0 && (
+                  <ul className="space-y-2 rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-3 text-sm">
+                    {activeGuide.steps.map((tipLine, idx) => (
+                      <li key={idx} className="flex items-start gap-2">
+                        <ClipboardList className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+                        <span>{tipLine}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
           <Card>
             <CardHeader className="flex flex-row items-center gap-2 pb-2">
               <Info className="h-5 w-5 text-primary" />
@@ -326,7 +456,7 @@ export default function OnboardingWrapper({ steps, index, setIndex, onComplete, 
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                {step?.tip || "Short and sweet: you can change this later in Settings."}
+                {step?.tip || activeGuide?.summary || "Short and sweet: you can change this later in Settings."}
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- add step-specific onboarding guidance with a dynamic right-rail checklist
- surface upload, segment, and publishing checklists inside episode creation steps
- introduce a guided tour, quickstart card, and background-music cheat sheet to the template editor

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4fb40dcb4832080e3f04bcb5a1181