### PR TITLE
Add podcast distribution checklist module

### DIFF
--- a/backend/api/services/distribution_directory.py
+++ b/backend/api/services/distribution_directory.py
@@ -1,0 +1,184 @@
+"""Central directory of podcast distribution platforms and helper metadata.
+
+The frontend uses this to render guidance for submitting RSS feeds to the
+most common directories. Each entry describes:
+
+* user-facing labels and summary text
+* the primary call-to-action link (optionally formatted with feed/show data)
+* documentation links and detailed instructions
+* requirements (RSS feed, Spreaker show, etc.)
+* the default automation level/status we can provide
+
+The data lives in one place so the API router can stay lean and we can update
+instructions without touching business logic.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, List, Optional
+
+
+# NOTE: Keep platform keys kebab- or snake-case (letters, digits, underscores)
+# so they can be safely used in URLs and database unique constraints.
+_PLATFORMS: List[Dict[str, object]] = [
+    {
+        "key": "spreaker",
+        "name": "Spreaker (CloudPod Hosting)",
+        "summary": "Episodes published from CloudPod are automatically hosted on Spreaker.",
+        "automation": "automatic",
+        "automation_notes": "We create and update the Spreaker show when you publish episodes.",
+        "instructions": [
+            "We sync your show details and episodes to Spreaker automatically whenever you publish from CloudPod.",
+            "Use the Spreaker dashboard to confirm artwork, categories, and analytics.",
+            "If you need the public page, copy it from the button below or Settings → Distribution in CloudPod.",
+        ],
+        "action_label": "Open Spreaker dashboard",
+        "action_url_template": "https://www.spreaker.com/show/{spreaker_show_id}",
+        "default_status": "completed",
+        "requires_spreaker_show": True,
+        "spreaker_missing_help": "Connect a Spreaker show in Settings or via the Manage Podcasts screen to generate this link.",
+    },
+    {
+        "key": "apple_podcasts",
+        "name": "Apple Podcasts",
+        "summary": "The largest podcast directory — required for Siri and the iOS Podcasts app.",
+        "automation": "manual",
+        "automation_notes": "Apple requires the creator to submit and accept updated terms directly.",
+        "action_label": "Open Podcasts Connect",
+        "action_url": "https://podcastsconnect.apple.com/",
+        "docs_url": "https://support.apple.com/en-us/HT204164",
+        "instructions": [
+            "Sign in with the Apple ID that will manage the show in Podcasts Connect.",
+            "Click the plus (+) button and choose ‘New Show’. Select ‘Add a show with an RSS feed’.",
+            "Paste your RSS feed URL: {rss_feed_url}.",
+            "Validate the feed, resolve any warnings, then click Submit. Apple usually reviews within 24–48 hours.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Publish at least one episode and link your show to Spreaker so we can generate your RSS feed.",
+    },
+    {
+        "key": "spotify",
+        "name": "Spotify for Podcasters",
+        "summary": "Submit to Spotify to reach Android, desktop, and smart speaker listeners.",
+        "automation": "assisted",
+        "automation_notes": "We provide a pre-filled submission link with your RSS feed.",
+        "action_label": "Submit to Spotify",
+        "action_url_template": "https://podcasters.spotify.com/submit?feed={rss_feed_encoded}",
+        "docs_url": "https://podcasters.spotify.com/",
+        "instructions": [
+            "Sign in to Spotify for Podcasters (or create an account).",
+            "Follow the claim flow; your RSS feed is pre-filled when you use our link.",
+            "Verify ownership via the email sent to your podcast contact address, then complete the show setup.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "We need your CloudPod RSS feed before we can pre-fill the Spotify form.",
+    },
+    {
+        "key": "amazon_music",
+        "name": "Amazon Music & Audible",
+        "summary": "List your show on Amazon Music, Audible, and Alexa devices.",
+        "automation": "manual",
+        "action_label": "Open Amazon Music for Podcasters",
+        "action_url": "https://podcasters.amazon.com/",
+        "docs_url": "https://podcasters.amazon.com/faq",
+        "instructions": [
+            "Sign in with your Amazon account at Amazon Music for Podcasters.",
+            "Choose ‘Add or Claim a Podcast’, then paste your RSS feed URL: {rss_feed_url}.",
+            "Confirm the regions where you want the show to appear and submit. Approval typically happens within a day.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Link your Spreaker show so we can surface the RSS feed for Amazon.",
+    },
+    {
+        "key": "iheart",
+        "name": "iHeartRadio",
+        "summary": "Reach listeners across the iHeartRadio app, smart speakers, and radio sites.",
+        "automation": "manual",
+        "action_label": "Apply on iHeartRadio",
+        "action_url": "https://www.iheart.com/podcast-submissions/",
+        "instructions": [
+            "Open the submission form and sign in or create a free creator account.",
+            "Paste your RSS feed URL ({rss_feed_url}) and complete the required metadata fields.",
+            "Submit the form. iHeartRadio reviews feeds manually; approval can take several business days.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Generate your CloudPod RSS feed before applying to iHeartRadio.",
+    },
+    {
+        "key": "tunein",
+        "name": "TuneIn",
+        "summary": "Distribute to car dashboards, Alexa, and Sonos via TuneIn.",
+        "automation": "manual",
+        "action_label": "Submit to TuneIn",
+        "action_url": "https://help.tunein.com/contact/add-podcast-S19TR3Sdf",
+        "instructions": [
+            "Open TuneIn’s podcast submission form.",
+            "Provide your show name, contact email, and paste the RSS feed URL: {rss_feed_url}.",
+            "Submit the request. TuneIn will email you once the show is approved and listed.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Publish a CloudPod RSS feed so TuneIn can ingest your show.",
+    },
+    {
+        "key": "pandora",
+        "name": "Pandora for Podcasters",
+        "summary": "Get featured on Pandora’s podcast genome for music-friendly audiences.",
+        "automation": "manual",
+        "action_label": "Open Pandora AMP",
+        "action_url": "https://podcasters.pandora.com/submit",
+        "instructions": [
+            "Sign in or create a Pandora AMP account.",
+            "Submit your RSS feed ({rss_feed_url}) via the ‘Submit Podcast’ flow.",
+            "Pandora performs a manual review focused on audio quality and metadata completeness.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Once your RSS feed is live we’ll pre-fill this step with your CloudPod URL.",
+    },
+    {
+        "key": "samsung_podcasts",
+        "name": "Samsung Free / Samsung Podcasts",
+        "summary": "Surface your show on Samsung Galaxy devices via the Samsung Free app.",
+        "automation": "manual",
+        "action_label": "Submit to Samsung Podcasts",
+        "action_url": "https://publishers.samsungfree.com/podcast/submit",
+        "instructions": [
+            "Create or sign in to a Samsung Publishers account.",
+            "Fill in the submission form and paste your RSS feed: {rss_feed_url}.",
+            "Samsung reviews submissions in batches; approval can take up to two weeks.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Create your CloudPod RSS feed first so Samsung can pull episodes.",
+    },
+    {
+        "key": "podchaser",
+        "name": "Podchaser",
+        "summary": "Claim your profile on Podchaser to manage credits and cross-promotion.",
+        "automation": "assisted",
+        "action_label": "Claim on Podchaser",
+        "action_url_template": "https://www.podchaser.com/podcasts/submit?url={rss_feed_encoded}",
+        "instructions": [
+            "Log in to Podchaser (or create an account).",
+            "Search for your show or use the submit link with the RSS feed ({rss_feed_url}).",
+            "Claim ownership to unlock analytics and collaboration tools.",
+        ],
+        "requires_rss_feed": True,
+        "rss_missing_help": "Publish your CloudPod RSS feed before claiming on Podchaser.",
+    },
+]
+
+
+def get_distribution_hosts() -> List[Dict[str, object]]:
+    """Return a deepcopy so callers can mutate safely."""
+
+    return deepcopy(_PLATFORMS)
+
+
+def get_distribution_host(key: str) -> Optional[Dict[str, object]]:
+    for entry in _PLATFORMS:
+        if entry.get("key") == key:
+            return deepcopy(entry)
+    return None
+
+
+__all__ = ["get_distribution_hosts", "get_distribution_host"]

--- a/backend/api/tests/api/test_distribution_checklist.py
+++ b/backend/api/tests/api/test_distribution_checklist.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session as DBSession
+
+# Provide minimal defaults so Settings() can initialize during import
+os.environ["INSTANCE_CONNECTION_NAME"] = ""
+_REQUIRED_KEYS = [
+    "DB_USER",
+    "DB_PASS",
+    "DB_NAME",
+    "GEMINI_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "ASSEMBLYAI_API_KEY",
+    "SPREAKER_API_TOKEN",
+    "SPREAKER_CLIENT_ID",
+    "SPREAKER_CLIENT_SECRET",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+]
+for key in _REQUIRED_KEYS:
+    os.environ.setdefault(key, "test")
+
+from api.main import app
+from api.core.database import engine
+from api.core import crud
+from api.models.user import UserCreate, User
+from api.models.podcast import Podcast
+from api.core.auth import get_current_user
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    original = dict(app.dependency_overrides)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def db() -> DBSession:
+    with DBSession(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def user(db: DBSession) -> User:
+    uc = UserCreate(
+        email=f"dist_{uuid.uuid4().hex[:10]}@example.com",
+        password="Password123!",
+    )
+    return crud.create_user(session=db, user_create=uc)
+
+
+@pytest.fixture
+def authed_client(client: TestClient, user: User) -> TestClient:
+    app.dependency_overrides[get_current_user] = lambda: user
+    return client
+
+
+@pytest.fixture
+def podcast(db: DBSession, user: User) -> Podcast:
+    pod = Podcast(
+        name="Distribution Demo Show",
+        description="Testing distribution checklist",
+        spreaker_show_id="1234567",
+        user_id=user.id,
+    )
+    db.add(pod)
+    db.commit()
+    db.refresh(pod)
+    return pod
+
+
+def _get_item(items: List[Dict], key: str) -> Dict:
+    for item in items:
+        if item.get("key") == key:
+            return item
+    raise AssertionError(f"Distribution item {key} not found")
+
+
+def test_distribution_checklist_includes_defaults(authed_client: TestClient, podcast: Podcast):
+    resp = authed_client.get(f"/api/podcasts/{podcast.id}/distribution/checklist")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["podcast_id"] == str(podcast.id)
+    assert body["rss_feed_url"].endswith("/episodes/feed")
+
+    items = body["items"]
+    keys = {item["key"] for item in items}
+    assert "spreaker" in keys
+    assert "apple_podcasts" in keys
+
+    spreaker = _get_item(items, "spreaker")
+    assert spreaker["status"] == "completed"
+    assert spreaker["disabled_reason"] is None
+
+    apple = _get_item(items, "apple_podcasts")
+    assert body["rss_feed_url"] in " ".join(apple["instructions"])
+    assert apple["requires_rss_feed"] is True
+
+
+def test_distribution_update_status_persists(authed_client: TestClient, podcast: Podcast):
+    url = f"/api/podcasts/{podcast.id}/distribution/checklist/spotify"
+    resp = authed_client.put(url, json={"status": "completed", "notes": "  published ✅  "})
+    assert resp.status_code == 200, resp.text
+    item = resp.json()
+    assert item["status"] == "completed"
+    assert item["notes"] == "published ✅"
+
+    resp2 = authed_client.get(f"/api/podcasts/{podcast.id}/distribution/checklist")
+    spotify = _get_item(resp2.json()["items"], "spotify")
+    assert spotify["status"] == "completed"
+    assert spotify["notes"] == "published ✅"
+
+
+def test_distribution_without_feed_marks_platforms_disabled(
+    authed_client: TestClient, db: DBSession, user: User
+):
+    pod = Podcast(name="No Feed Yet", user_id=user.id)
+    db.add(pod)
+    db.commit()
+    db.refresh(pod)
+
+    resp = authed_client.get(f"/api/podcasts/{pod.id}/distribution/checklist")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    apple = _get_item(items, "apple_podcasts")
+    assert apple["disabled_reason"]
+    assert "RSS" in apple["disabled_reason"]

--- a/frontend/src/components/dashboard/DistributionChecklistDialog.jsx
+++ b/frontend/src/components/dashboard/DistributionChecklistDialog.jsx
@@ -1,0 +1,331 @@
+import { useEffect, useMemo, useState } from "react";
+import * as Icons from "lucide-react";
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { makeApi } from "@/lib/apiClient";
+
+const STATUS_META = {
+  not_started: { label: "Not started", badge: "secondary" },
+  in_progress: { label: "In progress", badge: "outline" },
+  completed: { label: "Completed", badge: "default" },
+  skipped: { label: "Skipped", badge: "outline" },
+};
+
+const STATUS_OPTIONS = [
+  { value: "not_started", label: "Not started" },
+  { value: "in_progress", label: "In progress" },
+  { value: "completed", label: "Completed" },
+  { value: "skipped", label: "Skipped" },
+];
+
+const AUTOMATION_LABELS = {
+  automatic: "Handled automatically",
+  assisted: "Assisted submission",
+  manual: "Manual submission",
+};
+
+const automationBadgeVariant = {
+  automatic: "default",
+  assisted: "secondary",
+  manual: "outline",
+};
+
+function formatAutomationLabel(value) {
+  if (!value) return "Manual submission";
+  return AUTOMATION_LABELS[value] || value;
+}
+
+export default function DistributionChecklistDialog({ open, onOpenChange, podcast, token }) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [items, setItems] = useState([]);
+  const [notesDraft, setNotesDraft] = useState({});
+  const [rssFeedUrl, setRssFeedUrl] = useState("");
+  const [spreakerUrl, setSpreakerUrl] = useState("");
+  const [savingKeys, setSavingKeys] = useState({});
+
+  const podcastId = podcast?.id;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (!token || !podcastId) {
+      setItems([]);
+      setNotesDraft({});
+      setRssFeedUrl("");
+      setSpreakerUrl("");
+      return;
+    }
+
+    let aborted = false;
+    setLoading(true);
+    setError("");
+
+    makeApi(token)
+      .get(`/api/podcasts/${podcastId}/distribution/checklist`)
+      .then((data) => {
+        if (aborted) return;
+        const list = Array.isArray(data?.items) ? data.items : [];
+        setItems(list);
+        setNotesDraft(Object.fromEntries(list.map((item) => [item.key, item.notes || ""])));
+        setRssFeedUrl(data?.rss_feed_url || "");
+        setSpreakerUrl(data?.spreaker_show_url || "");
+      })
+      .catch((err) => {
+        if (aborted) return;
+        const detail = err?.detail || err?.message || "Unable to load distribution checklist.";
+        setError(detail);
+      })
+      .finally(() => {
+        if (!aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      aborted = true;
+    };
+  }, [open, token, podcastId]);
+
+  const statusByKey = useMemo(() => Object.fromEntries(items.map((item) => [item.key, item.status])), [items]);
+
+  const disabled = !podcastId || !token;
+
+  const handleCopyFeed = async () => {
+    if (!rssFeedUrl) return;
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(rssFeedUrl);
+      } else {
+        throw new Error("Clipboard API unavailable");
+      }
+      toast({ title: "RSS feed copied" });
+    } catch (err) {
+      toast({
+        title: "Copy failed",
+        description: err?.message || "Unable to copy RSS feed. Please copy it manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const saveItem = async (key, body) => {
+    if (!podcastId || !token) return;
+    setSavingKeys((prev) => ({ ...prev, [key]: true }));
+    try {
+      const data = await makeApi(token).put(
+        `/api/podcasts/${podcastId}/distribution/checklist/${encodeURIComponent(key)}`,
+        body
+      );
+      setItems((prev) => prev.map((item) => (item.key === key ? data : item)));
+      setNotesDraft((prev) => ({ ...prev, [key]: data?.notes || "" }));
+      toast({ title: data?.name ? `${data.name} saved` : "Checklist updated" });
+    } catch (err) {
+      const detail = err?.detail || err?.message || "Unable to save changes.";
+      toast({ title: "Save failed", description: detail, variant: "destructive" });
+    } finally {
+      setSavingKeys((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
+  };
+
+  const handleStatusChange = (key, newStatus) => {
+    const notes = notesDraft[key] ?? "";
+    saveItem(key, { status: newStatus, notes });
+  };
+
+  const handleSaveNotes = (key) => {
+    const status = statusByKey[key] ?? "not_started";
+    saveItem(key, { status, notes: notesDraft[key] ?? "" });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setError("");
+        }
+        onOpenChange?.(next);
+      }}
+    >
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle className="flex flex-col gap-1">
+            <span>Distribute your podcast</span>
+            {podcast?.name ? (
+              <span className="text-base font-normal text-muted-foreground">{podcast.name}</span>
+            ) : null}
+          </DialogTitle>
+          <DialogDescription className="space-y-3">
+            <p>
+              Work through the checklist below to submit your show to the major podcast directories. We provide direct links,
+              instructions, and keep track of what has been completed.
+            </p>
+            {rssFeedUrl ? (
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <span className="font-medium">RSS feed:</span>
+                <code className="rounded bg-muted px-2 py-1 text-xs break-all">{rssFeedUrl}</code>
+                <Button type="button" variant="outline" size="sm" onClick={handleCopyFeed}>
+                  <Icons.Clipboard className="mr-2 h-4 w-4" /> Copy
+                </Button>
+              </div>
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                Publish your first episode or link a Spreaker show to generate the RSS feed automatically.
+              </div>
+            )}
+            {spreakerUrl ? (
+              <div className="text-sm text-muted-foreground">
+                Spreaker show URL: <a href={spreakerUrl} target="_blank" rel="noreferrer" className="text-primary underline">{spreakerUrl}</a>
+              </div>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-muted-foreground">
+            <Icons.Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading distribution checklist…
+          </div>
+        ) : null}
+
+        {!loading && !error ? (
+          <div className="max-h-[65vh] space-y-4 overflow-y-auto pr-1">
+            {items.map((item) => {
+              const statusMeta = STATUS_META[item.status] || STATUS_META.not_started;
+              const automationLabel = formatAutomationLabel(item.automation);
+              const saving = Boolean(savingKeys[item.key]);
+              return (
+                <div key={item.key} className="rounded-lg border bg-card px-4 py-4 shadow-sm">
+                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-lg font-semibold">{item.name}</h3>
+                        <Badge variant={statusMeta.badge}>{statusMeta.label}</Badge>
+                        <Badge variant={automationBadgeVariant[item.automation] || "outline"}>{automationLabel}</Badge>
+                      </div>
+                      {item.summary ? <p className="text-sm text-muted-foreground">{item.summary}</p> : null}
+                      {item.automation_notes ? (
+                        <p className="text-xs text-muted-foreground">{item.automation_notes}</p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col items-start gap-2 md:items-end">
+                      {item.action_label && item.action_url ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          asChild
+                          disabled={Boolean(item.disabled_reason)}
+                        >
+                          <a href={item.action_url} target="_blank" rel="noreferrer">
+                            <Icons.ExternalLink className="mr-2 h-4 w-4" /> {item.action_label}
+                          </a>
+                        </Button>
+                      ) : null}
+                      {item.docs_url ? (
+                        <a
+                          href={item.docs_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-xs text-primary underline"
+                        >
+                          Platform documentation
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  {item.disabled_reason ? (
+                    <div className="mt-3 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-900 dark:text-yellow-100">
+                      {item.disabled_reason}
+                    </div>
+                  ) : null}
+
+                  {Array.isArray(item.instructions) && item.instructions.length > 0 ? (
+                    <ol className="mt-3 list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
+                      {item.instructions.map((step, idx) => (
+                        <li key={idx}>{step}</li>
+                      ))}
+                    </ol>
+                  ) : null}
+
+                  <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,220px)_minmax(0,1fr)] md:items-start">
+                    <div className="space-y-2">
+                      <Label htmlFor={`status-${item.key}`}>Status</Label>
+                      <Select
+                        value={item.status || "not_started"}
+                        onValueChange={(value) => handleStatusChange(item.key, value)}
+                        disabled={disabled}
+                      >
+                        <SelectTrigger id={`status-${item.key}`}>
+                          <SelectValue placeholder="Select status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {STATUS_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`notes-${item.key}`}>Notes</Label>
+                      <Textarea
+                        id={`notes-${item.key}`}
+                        value={notesDraft[item.key] ?? ""}
+                        onChange={(event) =>
+                          setNotesDraft((prev) => ({ ...prev, [item.key]: event.target.value }))
+                        }
+                        placeholder="Add reminders or follow-up steps for your team"
+                        rows={3}
+                        disabled={disabled}
+                      />
+                      <div className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span>Only visible inside CloudPod.</span>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleSaveNotes(item.key)}
+                          disabled={disabled || saving}
+                        >
+                          {saving ? <Icons.Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                          Save notes
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+
+            {items.length === 0 ? (
+              <div className="rounded-md border border-dashed border-muted px-4 py-8 text-center text-sm text-muted-foreground">
+                No distribution destinations available yet.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/dashboard/PodcastManager.jsx
+++ b/frontend/src/components/dashboard/PodcastManager.jsx
@@ -8,6 +8,7 @@ import * as Icons from "lucide-react";
 import { useState, useEffect } from "react";
 import EditPodcastDialog from "./EditPodcastDialog";
 import NewUserWizard from "./NewUserWizard";
+import DistributionChecklistDialog from "./DistributionChecklistDialog";
 import { useToast } from "@/hooks/use-toast";
 import { makeApi, buildApiUrl } from "@/lib/apiClient";
 
@@ -22,6 +23,8 @@ export default function PodcastManager({ onBack, token, podcasts, setPodcasts })
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const [recoveringId, setRecoveringId] = useState(null);
   const [publishingAllId, setPublishingAllId] = useState(null);
+  const [distributionOpen, setDistributionOpen] = useState(false);
+  const [distributionPodcast, setDistributionPodcast] = useState(null);
   const { toast } = useToast();
   const [isSpreakerConnected, setIsSpreakerConnected] = useState(false);
   const [me, setMe] = useState(null);
@@ -169,6 +172,18 @@ export default function PodcastManager({ onBack, token, podcasts, setPodcasts })
       toast({ title: "Error", description: err.message, variant: "destructive" });
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const openDistributionDialog = (podcast) => {
+    setDistributionPodcast(podcast);
+    setDistributionOpen(true);
+  };
+
+  const handleDistributionOpenChange = (open) => {
+    setDistributionOpen(open);
+    if (!open) {
+      setDistributionPodcast(null);
     }
   };
 
@@ -320,6 +335,9 @@ export default function PodcastManager({ onBack, token, podcasts, setPodcasts })
                     </div>
                   </div>
                   <div className="flex items-center space-x-2">
+                    <Button variant="outline" size="sm" onClick={() => openDistributionDialog(podcast)}>
+                      <Icons.Share2 className="w-4 h-4 mr-2" /> Distribution
+                    </Button>
                     {/* Spreaker publish/setup pills */}
                     {(() => {
                       const issues = getComplianceIssues(podcast);
@@ -485,6 +503,13 @@ export default function PodcastManager({ onBack, token, podcasts, setPodcasts })
           onPodcastCreated={handlePodcastCreated}
         />
       )}
+
+      <DistributionChecklistDialog
+        open={distributionOpen}
+        onOpenChange={handleDistributionOpenChange}
+        podcast={distributionPodcast}
+        token={token}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add database model, service metadata, and API endpoints to serve a podcast distribution checklist
- introduce dashboard dialog that guides users through submitting shows to major platforms and tracks completion state
- cover the new API with tests and hook the dialog into the podcast manager UI

## Testing
- pytest backend/api/tests/api/test_distribution_checklist.py

------
https://chatgpt.com/codex/tasks/task_e_68d6515f6d148320ab130401467480b7