### PR TITLE
Fix publish flow and improve template background music controls

### DIFF
--- a/backend/api/models/settings.py
+++ b/backend/api/models/settings.py
@@ -1,5 +1,8 @@
 from typing import Optional
 from datetime import datetime
+from datetime import datetime
+from typing import Optional
+
 from sqlmodel import SQLModel, Field, Session
 from pydantic import BaseModel
 import json
@@ -22,11 +25,16 @@ class AdminSettings(BaseModel):
 
     - test_mode: legacy toggle used by parts of the system/tests
     - default_user_active: whether newly created users start active (True) or inactive (False)
+    - maintenance_mode: when True, non-admin API requests are rejected with HTTP 503
+    - maintenance_message: optional string surfaced to clients when maintenance is active
     """
+
     test_mode: bool = False
     default_user_active: bool = True
     # Maximum upload size for main content (in MB). Exposed publicly for client hints.
     max_upload_mb: int = 500
+    maintenance_mode: bool = False
+    maintenance_message: Optional[str] = None
 
 
 def load_admin_settings(session: Session) -> AdminSettings:

--- a/backend/api/routers/episodes/write.py
+++ b/backend/api/routers/episodes/write.py
@@ -51,10 +51,19 @@ def update_episode_metadata(
 	if description is not None and description != ep.show_notes:
 		ep.show_notes = description
 		changed = True
-	cover_image_path = payload.get("cover_image_path")
-	if cover_image_path and cover_image_path != getattr(ep, 'cover_path', None):
-		ep.cover_path = cover_image_path
-		changed = True
+        if "cover_image_path" in payload:
+                cover_image_path = payload.get("cover_image_path")
+                if cover_image_path and cover_image_path != getattr(ep, 'cover_path', None):
+                        ep.cover_path = cover_image_path
+                        # When switching to a freshly uploaded cover, prefer the local path until publish sync updates remote.
+                        if hasattr(ep, 'remote_cover_url'):
+                                ep.remote_cover_url = None
+                        changed = True
+                elif cover_image_path is None and getattr(ep, 'cover_path', None):
+                        ep.cover_path = None
+                        if hasattr(ep, 'remote_cover_url'):
+                                ep.remote_cover_url = None
+                        changed = True
 	publish_state = payload.get("publish_state")
 	if publish_state is not None:
 		changed = True


### PR DESCRIPTION
## Summary
- add inline fallbacks for episode publish/schedule tasks and gate non-admin access during maintenance windows
- enforce processing-minute quotas during assembly and surface a user-facing dialog with upgrade and purchase options
- refresh template background music editing with 1–11 loudness scale, inline music uploads, and cover-art persistence fixes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68d70f580e748320af507ee0f0de3458