### PR TITLE
Add upload progress indicator for audio uploads

### DIFF
--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -44,6 +44,7 @@ export default function PodcastCreator({
     uploadedFile,
     uploadedFilename,
     isUploading,
+    uploadProgress,
     handleFileChange,
     fileInputRef,
     mediaLibrary,
@@ -196,6 +197,7 @@ export default function PodcastCreator({
             uploadedFile={uploadedFile}
             uploadedFilename={uploadedFilename}
             isUploading={isUploading}
+            uploadProgress={uploadProgress}
             onFileChange={handleFileChange}
             fileInputRef={fileInputRef}
             onBack={() => setCurrentStep(1)}

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
@@ -9,6 +9,7 @@ export default function StepUploadAudio({
   uploadedFile,
   uploadedFilename,
   isUploading,
+  uploadProgress = null,
   onFileChange,
   fileInputRef,
   onBack,
@@ -122,7 +123,9 @@ export default function StepUploadAudio({
             {(uploadedFile || uploadedFilename) ? (
               <div className="space-y-6">
                 <FileAudio className="w-16 h-16 mx-auto text-green-600" />
-                <p className="text-xl font-semibold text-green-600">File Ready!</p>
+                <p className={`text-xl font-semibold ${isUploading ? 'text-slate-600' : 'text-green-600'}`}>
+                  {isUploading ? 'Uploading your audio…' : 'File Ready!'}
+                </p>
                 {uploadedFile && <p className="text-gray-600">{formatDisplayName(uploadedFile.name)}</p>}
                 {!uploadedFile && uploadedFilename && (
                   <>
@@ -153,6 +156,19 @@ export default function StepUploadAudio({
                     </>
                   )}
                 </Button>
+              </div>
+            )}
+            {isUploading && (
+              <div className="mt-6 space-y-2">
+                <div className="h-2 w-full rounded-full bg-slate-200 overflow-hidden">
+                  <div
+                    className="h-full bg-slate-600 transition-all duration-200"
+                    style={{ width: `${Math.min(100, Math.max(5, typeof uploadProgress === 'number' ? uploadProgress : 5))}%` }}
+                  />
+                </div>
+                <p className="text-sm text-slate-600">
+                  Uploading{typeof uploadProgress === 'number' ? `… ${uploadProgress}%` : '…'}
+                </p>
               </div>
             )}
             <input ref={fileInputRef} type="file" accept="audio/*" onChange={handleFileInput} className="hidden" />


### PR DESCRIPTION
## Summary
- track audio upload progress with XMLHttpRequest and expose it from the podcast creator hook
- display a visible progress bar and uploading message during Step 2 of the wizard
- thread the progress state through the podcast creator component so the UI reflects upload status

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97d76a5108320af5e7f8cc52b5549