### PR TITLE
Improve AI enhancer error handling and clean audio orchestrator

### DIFF
--- a/backend/api/services/ai_enhancer.py
+++ b/backend/api/services/ai_enhancer.py
@@ -1,21 +1,28 @@
-﻿# api/services/ai_enhancer.py
-import os
-from typing import Optional
-from pydub import AudioSegment
+"""Text-to-speech helpers used by the AI enhancer features."""
+
+from __future__ import annotations
+
 import io
+from typing import Optional
+
+from pydub import AudioSegment
 
 try:
     import httpx
-    _HTTPX_AVAILABLE = True
-except ImportError:
-    httpx = None # type: ignore
-    _HTTPX_AVAILABLE = False
+except ImportError:  # pragma: no cover - optional dependency at runtime
+    httpx = None  # type: ignore[assignment]
 
 from api.core.config import settings
 from api.models.user import User
 
+
+_DEFAULT_ELEVENLABS_VOICE_ID = "21m00Tcm4TlvDq8ikWAM"  # Rachel
+_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
+
+
 class AIEnhancerError(Exception):
-    pass
+    """Raised when text-to-speech generation fails."""
+
 
 def generate_speech_from_text(
     text: str,
@@ -25,72 +32,76 @@ def generate_speech_from_text(
     speaking_rate: float = 1.0,
     user: Optional[User] = None,
 ) -> AudioSegment:
-    """
-    Generates speech from text using the specified provider (ElevenLabs or Google).
-    """
+    """Generate speech from text using the requested provider."""
+
     if provider == "elevenlabs":
-        try:
-            from elevenlabs.client import ElevenLabs
-        except ImportError:
-            raise AIEnhancerError("ElevenLabs client is not installed. Run 'pip install elevenlabs'.")
-
-        # Use user-specific key if available, otherwise fall back to system key
-        api_key = (user and user.elevenlabs_api_key) or settings.ELEVENLABS_API_KEY
-        if not api_key or api_key == "dummy":
-            raise AIEnhancerError("ElevenLabs API key is not configured on the server or for your user account.")
-
-        client = ElevenLabs(api_key=api_key)
-        
-        # Default voice if none provided.
-        # The high-level `generate` helper can resolve names, but the core `text_to_speech.convert` needs an ID.
-        # We'll hardcode the ID for the default "Rachel" voice.
-        voice_id_to_use = voice_id
-        if not voice_id_to_use:
-            voice_id_to_use = "21m00Tcm4TlvDq8ikWAM" # Default to "Rachel"
-
-        try:
-            # The `client.generate` method is a helper that can be inconsistent across library versions.
-            # Using the core `text_to_speech.convert` method is more stable.
-            audio_iterator = client.text_to_speech.convert(
-                voice_id=voice_id_to_use,
-                text=text,
-                model_id="eleven_multilingual_v2"
-            )
-
-            audio_bytes = b"".join(audio_iterator)
-
-            if not isinstance(audio_bytes, bytes) or not audio_bytes:
-                raise AIEnhancerError("ElevenLabs returned no audio data.")
-            
-            return AudioSegment.from_file(io.BytesIO(audio_bytes), format="mp3")
-        except Exception as e:
-            # Try to extract a more specific error from httpx exceptions
-            if _HTTPX_AVAILABLE and isinstance(e, httpx.HTTPStatusError):
-                status_code = e.response.status_code
-                try:
-                    details = e.response.json().get("detail", {})
-                    message = details.get("message", e.response.text)
-                except Exception:
-                    message = e.response.text
-                
-                if status_code == 401:
-                    raise AIEnhancerError("The provided ElevenLabs API key is invalid or lacks permissions.")
-                if status_code == 402:
-                    raise AIEnhancerError("ElevenLabs API call failed due to a billing issue. Please check your ElevenLabs account.")
-                if status_code == 422 and "voice_id" in message.lower():
-                    raise AIEnhancerError(f"The voice ID '{voice_id_to_use}' could not be found or is invalid.")
-                
-                raise AIEnhancerError(f"ElevenLabs API error ({status_code}): {message}")
-
-            # Fallback for other exception types
-            err_str = str(e).lower()
-            if "invalid api key" in err_str or "unauthorized" in err_str:
-                 raise AIEnhancerError("The provided ElevenLabs API key is invalid or lacks permissions.")
-            if "voice_id" in err_str and "not found" in err_str:
-                 raise AIEnhancerError(f"The voice ID '{voice_id_to_use}' could not be found.")
-            raise AIEnhancerError(f"ElevenLabs API error: {e}")
-
-    elif provider == "google":
+        return _generate_with_elevenlabs(text, voice_id=voice_id, user=user)
+    if provider == "google":
         raise AIEnhancerError("Google TTS provider is not yet implemented.")
-    else:
-        raise AIEnhancerError(f"Unsupported TTS provider: {provider}")
+    raise AIEnhancerError(f"Unsupported TTS provider: {provider}")
+
+
+def _generate_with_elevenlabs(
+    text: str,
+    *,
+    voice_id: str | None,
+    user: Optional[User],
+) -> AudioSegment:
+    try:
+        from elevenlabs.client import ElevenLabs
+    except ImportError as exc:  # pragma: no cover - dependency optional in tests
+        raise AIEnhancerError("ElevenLabs client is not installed. Run 'pip install elevenlabs'.") from exc
+
+    api_key = (user and user.elevenlabs_api_key) or settings.ELEVENLABS_API_KEY
+    if not api_key or api_key == "dummy":
+        raise AIEnhancerError("ElevenLabs API key is not configured on the server or for your user account.")
+
+    resolved_voice_id = voice_id or _DEFAULT_ELEVENLABS_VOICE_ID
+    client = ElevenLabs(api_key=api_key)
+
+    try:
+        iterator = client.text_to_speech.convert(
+            voice_id=resolved_voice_id,
+            text=text,
+            model_id=_ELEVENLABS_MODEL_ID,
+        )
+        audio_bytes = b"".join(iterator)
+    except Exception as exc:  # noqa: BLE001 - we normalise the error below
+        raise _translate_elevenlabs_error(exc, resolved_voice_id)
+
+    if not isinstance(audio_bytes, bytes) or not audio_bytes:
+        raise AIEnhancerError("ElevenLabs returned no audio data.")
+
+    return AudioSegment.from_file(io.BytesIO(audio_bytes), format="mp3")
+
+
+def _translate_elevenlabs_error(exc: Exception, voice_id: str) -> AIEnhancerError:
+    """Convert ElevenLabs exceptions into human friendly messages."""
+
+    if httpx is not None and isinstance(exc, httpx.HTTPStatusError):  # type: ignore[attr-defined]
+        status_code = exc.response.status_code
+        try:
+            details = exc.response.json().get("detail", {})
+            message = details.get("message", exc.response.text)
+        except Exception:  # pragma: no cover - defensive guard
+            message = exc.response.text
+
+        lowered = message.lower()
+        if status_code == 401 or "invalid api key" in lowered or "unauthorized" in lowered:
+            return AIEnhancerError("The provided ElevenLabs API key is invalid or lacks permissions.")
+        if status_code == 402:
+            return AIEnhancerError(
+                "ElevenLabs API call failed due to a billing issue. Please check your ElevenLabs account."
+            )
+        if status_code == 422 and "voice_id" in lowered:
+            return AIEnhancerError(f"The voice ID '{voice_id}' could not be found or is invalid.")
+
+        return AIEnhancerError(f"ElevenLabs API error ({status_code}): {message}")
+
+    message = str(exc).lower()
+    if "invalid api key" in message or "unauthorized" in message:
+        return AIEnhancerError("The provided ElevenLabs API key is invalid or lacks permissions.")
+    if "voice_id" in message and "not found" in message:
+        return AIEnhancerError(f"The voice ID '{voice_id}' could not be found.")
+
+    return AIEnhancerError(f"ElevenLabs API error: {exc}")

--- a/backend/api/tests/services/test_ai_enhancer.py
+++ b/backend/api/tests/services/test_ai_enhancer.py
@@ -1,0 +1,57 @@
+import os
+import types
+
+import pytest
+
+for _env_key in [
+    "DB_USER",
+    "DB_PASS",
+    "DB_NAME",
+    "INSTANCE_CONNECTION_NAME",
+    "GEMINI_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "ASSEMBLYAI_API_KEY",
+    "SPREAKER_API_TOKEN",
+    "SPREAKER_CLIENT_ID",
+    "SPREAKER_CLIENT_SECRET",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+]:
+    os.environ.setdefault(_env_key, "test-value")
+
+from api.services import ai_enhancer
+
+
+def test_google_provider_not_implemented():
+    with pytest.raises(ai_enhancer.AIEnhancerError) as exc:
+        ai_enhancer.generate_speech_from_text("hello", provider="google")
+    assert "not yet implemented" in str(exc.value)
+
+
+def test_unsupported_provider():
+    with pytest.raises(ai_enhancer.AIEnhancerError) as exc:
+        ai_enhancer.generate_speech_from_text("hello", provider="unknown")
+    assert "Unsupported TTS provider" in str(exc.value)
+
+
+def test_translate_error_voice_not_found(monkeypatch):
+    fake_httpx = types.SimpleNamespace(HTTPStatusError=Exception)
+    monkeypatch.setattr(ai_enhancer, "httpx", fake_httpx)
+
+    class FakeResponse:
+        status_code = 422
+
+        @staticmethod
+        def json():
+            return {"detail": {"message": "voice_id not found"}}
+
+        text = "voice_id not found"
+
+    class FakeError(Exception):
+        def __init__(self):
+            self.response = FakeResponse()
+
+    err = ai_enhancer._translate_elevenlabs_error(FakeError(), "abc123")
+    assert "abc123" in str(err)


### PR DESCRIPTION
## Summary
- refactor the AI enhancer module to split provider-specific code and normalize ElevenLabs errors
- remove unused helpers and duplicate comments from the audio orchestrator shim
- add regression tests covering provider selection and error translation for the AI enhancer

## Testing
- pytest backend/api/tests/services/test_ai_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68da3eb5153883208dc97f8677331160