### PR TITLE
Refine RSS import flow and manage podcasts UI

### DIFF
--- a/backend/api/routers/podcasts/spreaker.py
+++ b/backend/api/routers/podcasts/spreaker.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, select
 
 from ...core.auth import get_current_user
 from ...core.database import get_session
-from ...models.podcast import Episode, EpisodeStatus, Podcast
+from ...models.podcast import Episode, EpisodeStatus, Podcast, PodcastImportState
 from ...models.user import User
 from ...services.episodes import publisher as episode_publisher
 from ...services.publisher import SpreakerClient
@@ -200,6 +200,17 @@ async def recover_spreaker_episodes(
         + "."
     )
 
+    state = session.get(PodcastImportState, podcast.id)
+    import_status = None
+    if state:
+        import_status = {
+            "source": state.source,
+            "feed_total": state.feed_total,
+            "imported_count": state.imported_count,
+            "needs_full_import": state.needs_full_import,
+            "updated_at": state.updated_at.isoformat() if state.updated_at else None,
+        }
+
     return {
         "recovered_count": created,
         "updated_count": updated,
@@ -207,6 +218,7 @@ async def recover_spreaker_episodes(
         "duplicates": summary.get("duplicates"),
         "conflicts": summary.get("conflicts", []),
         "message": message,
+        "import_status": import_status,
     }
 
 

--- a/backend/worker/tasks/app.py
+++ b/backend/worker/tasks/app.py
@@ -88,11 +88,16 @@ try:
     celery_app.conf.update(
         timezone=tz,
         beat_schedule={
-        "purge-expired-uploads-2am-pt": {
-            "task": "maintenance.purge_expired_uploads",
-            "schedule": crontab(hour=2, minute=0),
+            "purge-expired-uploads-2am-pt": {
+                "task": "maintenance.purge_expired_uploads",
+                "schedule": crontab(hour=2, minute=0),
+            },
+            "purge-published-mirrors-315am-pt": {
+                "task": "maintenance.purge_published_episode_mirrors",
+                "schedule": crontab(hour=3, minute=15),
+            },
         }
-    })
+    )
     logging.info("[celery] Beat schedule configured for purge at 2:00 in %s", tz)
 except Exception:
     logging.warning("[celery] Failed to configure beat schedule", exc_info=True)

--- a/backend/worker/tasks/maintenance.py
+++ b/backend/worker/tasks/maintenance.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+import json
+from datetime import datetime, timedelta
+
+from pathlib import Path
 
 from sqlmodel import select
 
 from .app import celery_app
 from api.core.database import get_session
-from api.core.paths import MEDIA_DIR
+from api.core.paths import MEDIA_DIR, FINAL_DIR
 from api.models.podcast import Episode, MediaCategory, MediaItem
+from infrastructure.gcs import delete_blob
 
 try:  # pragma: no cover - Python <3.9 fallback
     from zoneinfo import ZoneInfo
@@ -97,3 +101,81 @@ def purge_expired_uploads() -> dict:
         skipped_in_use,
     )
     return {"checked": checked, "removed": removed, "skipped_in_use": skipped_in_use}
+
+
+@celery_app.task(name="maintenance.purge_published_episode_mirrors")
+def purge_published_episode_mirrors() -> dict:
+    """Remove mirrored audio for episodes published to Spreaker more than 7 days ago."""
+
+    session = next(get_session())
+    cutoff = datetime.utcnow() - timedelta(days=7)
+    checked = 0
+    removed_local = 0
+    removed_remote = 0
+
+    try:
+        episodes = session.exec(
+            select(Episode).where(Episode.spreaker_episode_id != None)  # type: ignore
+        ).all()
+
+        for episode in episodes:
+            try:
+                meta = json.loads(getattr(episode, "meta_json", "{}") or "{}")
+                if not isinstance(meta, dict):
+                    meta = {}
+            except Exception:
+                meta = {}
+
+            local_basename = meta.get("mirrored_local_basename")
+            if not local_basename:
+                continue
+
+            publish_at = getattr(episode, "publish_at", None) or getattr(episode, "processed_at", None)
+            if not publish_at or publish_at > cutoff:
+                continue
+
+            checked += 1
+            local_path = (FINAL_DIR / Path(str(local_basename)).name).resolve()
+            if local_path.exists():
+                try:
+                    local_path.unlink()
+                    removed_local += 1
+                except Exception:
+                    logging.warning("[purge] failed to delete mirrored audio %s", local_path, exc_info=True)
+
+            gcs_uri = meta.get("mirrored_gcs_uri")
+            if isinstance(gcs_uri, str) and gcs_uri.startswith("gs://"):
+                try:
+                    bucket_key = gcs_uri[5:]
+                    bucket, _, key = bucket_key.partition("/")
+                    if bucket and key:
+                        delete_blob(bucket, key)
+                        removed_remote += 1
+                except Exception:
+                    logging.warning("[purge] failed to delete mirrored blob %s", gcs_uri, exc_info=True)
+
+            meta.pop("mirrored_local_basename", None)
+            meta.pop("mirrored_gcs_uri", None)
+            meta["mirrored_local_removed_at"] = datetime.utcnow().isoformat() + "Z"
+            episode.meta_json = json.dumps(meta)
+            session.add(episode)
+
+        if removed_local or removed_remote:
+            session.commit()
+    except Exception:
+        session.rollback()
+        logging.warning("[purge] purge_published_episode_mirrors failed", exc_info=True)
+    finally:
+        session.close()
+
+    logging.info(
+        "[purge] mirrors: checked=%s removed_local=%s removed_remote=%s",
+        checked,
+        removed_local,
+        removed_remote,
+    )
+    return {
+        "checked": checked,
+        "removed_local": removed_local,
+        "removed_remote": removed_remote,
+    }

--- a/backend/worker/tasks/publish.py
+++ b/backend/worker/tasks/publish.py
@@ -203,6 +203,8 @@ def publish_episode_to_spreaker_task(
                         exc_info=True,
                     )
 
+        remote_stream_url: Optional[str] = None
+
         try:
             if isinstance(result, dict) and result.get("episode_id"):
                 ep_id = str(result["episode_id"])
@@ -215,6 +217,7 @@ def publish_episode_to_spreaker_task(
                         or ep_obj.get("image_original_url")
                         or ep_obj.get("image_large_url")
                     )
+                    remote_stream_url = ep_obj.get("download_url") or ep_obj.get("stream_url")
                 if not remote_url and image_file_path and os.path.isfile(image_file_path):
                     try:
                         ok_img, _ = client.update_episode_image(ep_id, image_file_path)
@@ -242,6 +245,7 @@ def publish_episode_to_spreaker_task(
                             or ep_obj.get("image_original_url")
                             or ep_obj.get("image_large_url")
                         )
+                        remote_stream_url = remote_stream_url or ep_obj.get("download_url") or ep_obj.get("stream_url")
                 if remote_url:
                     if remote_url != getattr(episode, "remote_cover_url", None):
                         setattr(episode, "remote_cover_url", remote_url)
@@ -265,6 +269,8 @@ def publish_episode_to_spreaker_task(
 
         if isinstance(result, dict) and result.get("episode_id"):
             episode.spreaker_episode_id = str(result["episode_id"])
+            if remote_stream_url:
+                episode.final_audio_path = remote_stream_url
 
         episode.spreaker_publish_error = None
         episode.spreaker_publish_error_detail = None


### PR DESCRIPTION
## Summary
- add podcast import state tracking so the RSS importer can preview only the latest episodes and record when a full import is still needed
- tighten the RSS importer workflow by auto-detecting Spreaker feeds, limiting the initial download to a five episode preview, updating recovery to pull descriptions, and scheduling cleanup of mirrored audio after seven days
- redesign the manage podcasts dashboard with larger cards, an import reminder banner, and dedicated action buttons

## Testing
- pytest backend/api/tests *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68dad5388f788320923be237c147ea37