### PR TITLE
Enhance website generator with cover-based theming

### DIFF
--- a/backend/api/services/podcast_websites.py
+++ b/backend/api/services/podcast_websites.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
-from dataclasses import dataclass
+from collections import Counter
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 from uuid import UUID
 
+import requests
 from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
@@ -22,6 +25,13 @@ try:  # pragma: no cover - optional dependency in local dev
 except Exception:  # pragma: no cover
     storage = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency in local dev
+    from PIL import Image  # type: ignore
+except Exception:  # pragma: no cover
+    Image = None  # type: ignore
+import io
+import colorsys
+
 log = logging.getLogger(__name__)
 
 _SITE_SCHEMA_PROMPT = """
@@ -31,6 +41,7 @@ ALWAYS respond with a single JSON object matching this schema exactly:
 {
   "hero_title": string,              # big headline for the hero section
   "hero_subtitle": string,           # supportive subtitle or elevator pitch
+  "hero_image_url": string | null,   # podcast cover or on-brand hero image
   "about": {
       "heading": string,
       "body": string                # 2-3 short paragraphs in markdown-compatible text
@@ -53,6 +64,14 @@ ALWAYS respond with a single JSON object matching this schema exactly:
       "button_label": string,
       "button_url": string
   },
+  "section_suggestions": [
+      {
+          "type": string,               # semantic identifier e.g. "newsletter", "events"
+          "label": string,              # short client-facing label
+          "description": string,        # 1-2 sentence idea for the section content
+          "include_by_default": boolean # true when this section should be pre-populated on the layout
+      }
+  ],
   "additional_sections": [
       {
           "type": string,           # e.g. "newsletter", "testimonials"
@@ -67,6 +86,8 @@ ALWAYS respond with a single JSON object matching this schema exactly:
       "accent_color": string
   }
 }
+Craft ~10 distinct section_suggestion entries (do NOT include a basic "Listen now" card) that a client could toggle on/off.
+For any suggestion where include_by_default is true, add a corresponding entry to additional_sections so the preview feels complete.
 Do not include Markdown fences or explanations—return JSON only.
 """.strip()
 
@@ -76,16 +97,81 @@ _CUSTOM_DOMAIN_MIN_TIER = settings.PODCAST_WEBSITE_CUSTOM_DOMAIN_MIN_TIER.strip(
 
 _TIER_ORDER = ["free", "creator", "pro", "unlimited"]
 
+DEFAULT_SECTION_SUGGESTIONS: List[Dict[str, Any]] = [
+    {
+        "type": "newsletter",
+        "label": "Newsletter Sign-up",
+        "description": "Collect emails from superfans who want updates and bonus content.",
+        "include_by_default": True,
+    },
+    {
+        "type": "testimonials",
+        "label": "Listener Testimonials",
+        "description": "Highlight quotes from reviews to build trust with newcomers.",
+        "include_by_default": True,
+    },
+    {
+        "type": "hosts",
+        "label": "Meet the Hosts",
+        "description": "Introduce each host with a short story that shows their personality.",
+        "include_by_default": False,
+    },
+    {
+        "type": "events",
+        "label": "Upcoming Events",
+        "description": "Promote live shows, AMAs, or conference appearances.",
+        "include_by_default": False,
+    },
+    {
+        "type": "community",
+        "label": "Community Highlights",
+        "description": "Feature fan art, shout-outs, or social media conversations.",
+        "include_by_default": False,
+    },
+    {
+        "type": "press",
+        "label": "Press & Media",
+        "description": "List notable press coverage and media kits for collaborators.",
+        "include_by_default": False,
+    },
+    {
+        "type": "sponsors",
+        "label": "Sponsor Spotlight",
+        "description": "Thank sponsors or partners and include calls-to-action for inquiries.",
+        "include_by_default": False,
+    },
+    {
+        "type": "resources",
+        "label": "Resource Library",
+        "description": "Share guides, downloads, or companion materials mentioned in episodes.",
+        "include_by_default": False,
+    },
+    {
+        "type": "faqs",
+        "label": "FAQ",
+        "description": "Answer the top questions new listeners and collaborators ask.",
+        "include_by_default": False,
+    },
+    {
+        "type": "support",
+        "label": "Support the Show",
+        "description": "Provide Patreon, merch, or donation links for fans who want to contribute.",
+        "include_by_default": True,
+    },
+]
+
 
 class PodcastWebsiteContent(BaseModel):
     """Lightweight typed representation of website content."""
 
     hero_title: str = ""
     hero_subtitle: str = ""
+    hero_image_url: Optional[str] = None
     about: Dict[str, Any] = Field(default_factory=dict)
     hosts: List[Dict[str, str]] = Field(default_factory=list)
     episodes: List[Dict[str, Any]] = Field(default_factory=list)
     call_to_action: Dict[str, Any] = Field(default_factory=dict)
+    section_suggestions: List[Dict[str, Any]] = Field(default_factory=list)
     additional_sections: List[Dict[str, Any]] = Field(default_factory=list)
     theme: Dict[str, Any] = Field(default_factory=dict)
 
@@ -99,9 +185,15 @@ class WebsiteContext:
     host_names: List[str]
     episodes: List[Episode]
     base_domain: str = _BASE_DOMAIN
+    cover_url: Optional[str] = None
+    theme_colors: Dict[str, str] = field(default_factory=dict)
 
     def default_layout(self) -> Dict[str, Any]:
         """Fallback layout when AI output is incomplete."""
+
+        primary_color = (self.theme_colors or {}).get("primary_color", "#1F2A44")
+        secondary_color = (self.theme_colors or {}).get("secondary_color", "#F5F6FA")
+        accent_color = (self.theme_colors or {}).get("accent_color", "#FF7A59")
 
         ep_cards = [
             {
@@ -116,6 +208,7 @@ class WebsiteContext:
         return {
             "hero_title": self.podcast.name,
             "hero_subtitle": (self.podcast.description or "A podcast hosted on Podcast Plus Plus").strip(),
+            "hero_image_url": self.cover_url,
             "about": {
                 "heading": f"About {self.podcast.name}",
                 "body": (self.podcast.description or "We're still learning about this show!").strip(),
@@ -131,11 +224,12 @@ class WebsiteContext:
                 "button_label": "Subscribe now",
                 "button_url": f"https://{self.base_domain}",
             },
+            "section_suggestions": [dict(section) for section in DEFAULT_SECTION_SUGGESTIONS],
             "additional_sections": [],
             "theme": {
-                "primary_color": "#1F2A44",
-                "secondary_color": "#F5F6FA",
-                "accent_color": "#FF7A59",
+                "primary_color": primary_color,
+                "secondary_color": secondary_color,
+                "accent_color": accent_color,
             },
         }
 
@@ -198,6 +292,86 @@ def _fetch_recent_episodes(session: Session, podcast_id: UUID, limit: int = 6) -
     return episodes
 
 
+def _color_distance(c1: Tuple[int, int, int], c2: Tuple[int, int, int]) -> float:
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(c1, c2)))
+
+
+def _rgb_to_hex(color: Tuple[int, int, int]) -> str:
+    r, g, b = color
+    return f"#{r:02X}{g:02X}{b:02X}"
+
+
+def _extract_theme_colors(image_bytes: bytes) -> Dict[str, str]:
+    if Image is None:
+        return {}
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            img = img.convert("RGB")
+            img.thumbnail((160, 160))
+            pixels = list(img.getdata())
+    except Exception as exc:  # pragma: no cover - pillow decoding failure
+        log.debug("Failed to decode cover image for palette extraction: %s", exc)
+        return {}
+
+    if not pixels:
+        return {}
+
+    counts: Counter[Tuple[int, int, int]] = Counter(pixels)
+    most_common = [color for color, _ in counts.most_common(32)]
+    if not most_common:
+        return {}
+
+    primary = most_common[0]
+
+    distinct: List[Tuple[int, int, int]] = [primary]
+    for color in most_common[1:]:
+        if all(_color_distance(color, existing) > 40 for existing in distinct):
+            distinct.append(color)
+        if len(distinct) >= 5:
+            break
+
+    secondary = distinct[1] if len(distinct) > 1 else primary
+
+    def _saturation(color: Tuple[int, int, int]) -> float:
+        r, g, b = (channel / 255.0 for channel in color)
+        _, l, s = colorsys.rgb_to_hls(r, g, b)
+        # prefer moderately bright colors for accents
+        return (s * 0.7) + (1 - abs(0.5 - l)) * 0.3
+
+    accent_candidates = [c for c in distinct[1:]] or most_common[1:]
+    accent = None
+    for candidate in accent_candidates:
+        if _color_distance(candidate, primary) > 55 and _color_distance(candidate, secondary) > 40:
+            accent = candidate
+            break
+    if accent is None and accent_candidates:
+        accent = max(accent_candidates, key=_saturation)
+    if accent is None:
+        accent = primary
+
+    return {
+        "primary_color": _rgb_to_hex(primary),
+        "secondary_color": _rgb_to_hex(secondary),
+        "accent_color": _rgb_to_hex(accent),
+    }
+
+
+def _derive_visual_identity(podcast: Podcast) -> Tuple[Optional[str], Dict[str, str]]:
+    cover_url = podcast.preferred_cover_url
+    theme: Dict[str, str] = {}
+    if not cover_url:
+        return None, theme
+    try:
+        response = requests.get(cover_url, timeout=5)
+        if response.status_code == 200 and response.content:
+            palette = _extract_theme_colors(response.content)
+            if palette:
+                theme = palette
+    except Exception as exc:  # pragma: no cover - network issues
+        log.debug("Failed to fetch cover image for podcast %s: %s", podcast.id, exc)
+    return cover_url, theme
+
+
 def _build_context_prompt(ctx: WebsiteContext, include_layout: Optional[Dict[str, Any]] = None, user_request: Optional[str] = None) -> str:
     lines = [
         _SITE_SCHEMA_PROMPT,
@@ -214,6 +388,15 @@ def _build_context_prompt(ctx: WebsiteContext, include_layout: Optional[Dict[str
         lines.append(f"- {ep.title} (id: {ep.id}) :: {summary or 'No summary yet.'}")
     lines.append("")
     lines.append(f"Base subdomain: https://{ctx.podcast.name.lower().replace(' ', '-')}.{ctx.base_domain}")
+    if ctx.cover_url:
+        lines.append(f"Podcast cover image URL: {ctx.cover_url}")
+        if ctx.theme_colors:
+            lines.append(
+                "Suggested brand colors from the cover image: "
+                f"primary={ctx.theme_colors.get('primary_color')}, "
+                f"secondary={ctx.theme_colors.get('secondary_color')}, "
+                f"accent={ctx.theme_colors.get('accent_color')}"
+            )
     if include_layout:
         lines.append("Current website JSON:")
         lines.append(json.dumps(include_layout, indent=2))
@@ -251,6 +434,11 @@ def _normalize_layout(data: Dict[str, Any], ctx: WebsiteContext) -> PodcastWebsi
 
     merged["hero_title"] = str(data.get("hero_title") or baseline["hero_title"]).strip() or baseline["hero_title"]
     merged["hero_subtitle"] = str(data.get("hero_subtitle") or baseline["hero_subtitle"]).strip() or baseline["hero_subtitle"]
+    hero_image_url = data.get("hero_image_url")
+    if isinstance(hero_image_url, str) and hero_image_url.strip():
+        merged["hero_image_url"] = hero_image_url.strip()
+    else:
+        merged["hero_image_url"] = baseline.get("hero_image_url")
 
     about = data.get("about") or {}
     if not isinstance(about, dict):
@@ -308,6 +496,28 @@ def _normalize_layout(data: Dict[str, Any], ctx: WebsiteContext) -> PodcastWebsi
         "button_url": str(raw_cta.get("button_url") or baseline["call_to_action"]["button_url"]).strip() or baseline["call_to_action"]["button_url"],
     }
 
+    raw_suggestions = data.get("section_suggestions")
+    suggestions: List[Dict[str, Any]] = []
+    if isinstance(raw_suggestions, list):
+        for suggestion in raw_suggestions:
+            if not isinstance(suggestion, dict):
+                continue
+            type_val = str(suggestion.get("type") or "custom").strip() or "custom"
+            label_val = str(suggestion.get("label") or type_val.title()).strip()
+            description_val = str(suggestion.get("description") or "").strip()
+            include_val = bool(suggestion.get("include_by_default"))
+            suggestions.append(
+                {
+                    "type": type_val,
+                    "label": label_val,
+                    "description": description_val,
+                    "include_by_default": include_val,
+                }
+            )
+    if not suggestions:
+        suggestions = [dict(section) for section in DEFAULT_SECTION_SUGGESTIONS]
+    merged["section_suggestions"] = suggestions[:12]
+
     raw_sections = data.get("additional_sections")
     sections: List[Dict[str, Any]] = []
     if isinstance(raw_sections, list):
@@ -324,6 +534,17 @@ def _normalize_layout(data: Dict[str, Any], ctx: WebsiteContext) -> PodcastWebsi
                 "body": body_val,
                 "items": items_val,
             })
+    if not sections:
+        sections = [
+            {
+                "type": suggestion["type"],
+                "heading": suggestion["label"],
+                "body": suggestion.get("description", ""),
+                "items": [],
+            }
+            for suggestion in suggestions
+            if suggestion.get("include_by_default")
+        ]
     merged["additional_sections"] = sections
 
     theme = data.get("theme") if isinstance(data.get("theme"), dict) else {}
@@ -404,10 +625,13 @@ def create_or_refresh_site(session: Session, podcast: Podcast, user: User) -> Tu
         # ensure slug remains unique even if podcast renamed
         website.subdomain = _ensure_unique_subdomain(session, desired_slug, website.id)
 
+    cover_url, theme = _derive_visual_identity(podcast)
     ctx = WebsiteContext(
         podcast=podcast,
         host_names=_discover_hosts(podcast, user),
         episodes=_fetch_recent_episodes(session, podcast.id),
+        cover_url=cover_url,
+        theme_colors=theme,
     )
 
     prompt = _build_context_prompt(ctx)
@@ -437,10 +661,13 @@ def apply_ai_update(session: Session, website: PodcastWebsite, podcast: Podcast,
     if not request_text.strip():
         raise PodcastWebsiteAIError("Update request cannot be empty")
 
+    cover_url, theme = _derive_visual_identity(podcast)
     ctx = WebsiteContext(
         podcast=podcast,
         host_names=_discover_hosts(podcast, user),
         episodes=_fetch_recent_episodes(session, podcast.id),
+        cover_url=cover_url,
+        theme_colors=theme,
     )
 
     current_layout = website.parsed_layout()

--- a/backend/api/tests/api/test_podcast_websites.py
+++ b/backend/api/tests/api/test_podcast_websites.py
@@ -111,6 +111,7 @@ def _base_layout_for(episode: Episode) -> dict:
     return {
         "hero_title": "AI Builder Central",
         "hero_subtitle": "Launch your site in minutes.",
+        "hero_image_url": "https://example.com/cover.jpg",
         "about": {
             "heading": "About the show",
             "body": "We cover automation for podcasters.",
@@ -133,6 +134,20 @@ def _base_layout_for(episode: Episode) -> dict:
             "button_label": "Listen now",
             "button_url": "https://example.com",
         },
+        "section_suggestions": [
+            {
+                "type": "newsletter",
+                "label": "Join the newsletter",
+                "description": "Fans get new episode drops via email.",
+                "include_by_default": True,
+            },
+            {
+                "type": "press",
+                "label": "Press kit",
+                "description": "A quick overview for collaborators.",
+                "include_by_default": False,
+            },
+        ],
         "additional_sections": [],
         "theme": {
             "primary_color": "#123456",
@@ -162,6 +177,8 @@ def test_generate_website_creates_record(authed_client: TestClient, db: DBSessio
     assert body["default_domain"].endswith("podcastplusplus.com")
     assert body["layout"]["hero_title"] == "AI Builder Central"
     assert body["layout"]["episodes"][0]["episode_id"] == str(episode.id)
+    assert body["layout"]["hero_image_url"] == "https://example.com/cover.jpg"
+    assert len(body["layout"].get("section_suggestions", [])) >= 2
 
     site = db.exec(select(PodcastWebsite).where(PodcastWebsite.podcast_id == podcast.id)).first()
     assert site is not None
@@ -193,6 +210,7 @@ def test_chat_endpoint_updates_layout(authed_client: TestClient, db: DBSession, 
     layout = resp.json()["layout"]
     assert layout["hero_title"] == "AI Builder Hub"
     assert layout["call_to_action"]["button_label"] == "Join the Hub"
+    assert layout["section_suggestions"][0]["include_by_default"] is True
 
     site = db.exec(select(PodcastWebsite).where(PodcastWebsite.podcast_id == podcast.id)).first()
     assert site is not None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ email-validator
 itsdangerous
 pydantic-settings
 requests
+Pillow
 google-cloud-speech
 pydub
 

--- a/frontend/src/components/dashboard/WebsiteBuilder.jsx
+++ b/frontend/src/components/dashboard/WebsiteBuilder.jsx
@@ -52,6 +52,7 @@ function PreviewSection({ website }) {
   const heroBg = theme.primary_color || "#0f172a";
   const heroFg = theme.secondary_color || "#ffffff";
   const accent = theme.accent_color || "#2563eb";
+  const heroImage = layout.hero_image_url;
   const liveUrl = website.custom_domain
     ? `https://${website.custom_domain}`
     : website.default_domain
@@ -64,22 +65,35 @@ function PreviewSection({ website }) {
         className="rounded-2xl shadow-sm overflow-hidden"
         style={{ backgroundColor: heroBg, color: heroFg }}
       >
-        <div className="p-8 md:p-12 space-y-4">
-          <div className="text-xs uppercase tracking-[0.3em] opacity-80">Podcast Plus Plus</div>
-          <h2 className="text-3xl md:text-5xl font-semibold leading-tight">{layout.hero_title || "Your podcast"}</h2>
-          {layout.hero_subtitle && (
-            <p className="text-base md:text-lg max-w-2xl opacity-90">{layout.hero_subtitle}</p>
-          )}
-          {liveUrl && (
-            <Button
-              asChild
-              size="sm"
-              className="mt-2 bg-white text-slate-900 hover:bg-slate-200"
-            >
-              <a href={liveUrl} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="mr-2 h-4 w-4" /> View live site
-              </a>
-            </Button>
+        <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_minmax(0,0.75fr)]">
+          <div className="p-8 md:p-12 space-y-4">
+            <div className="text-xs uppercase tracking-[0.3em] opacity-80">Podcast Plus Plus</div>
+            <h2 className="text-3xl md:text-5xl font-semibold leading-tight">{layout.hero_title || "Your podcast"}</h2>
+            {layout.hero_subtitle && (
+              <p className="text-base md:text-lg max-w-2xl opacity-90">{layout.hero_subtitle}</p>
+            )}
+            {liveUrl && (
+              <Button
+                asChild
+                size="sm"
+                className="mt-2 bg-white text-slate-900 hover:bg-slate-200"
+              >
+                <a href={liveUrl} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="mr-2 h-4 w-4" /> View live site
+                </a>
+              </Button>
+            )}
+          </div>
+          {heroImage && (
+            <div className="relative flex items-center justify-center bg-slate-900/10 p-6 md:p-8">
+              <div className="relative aspect-square w-full max-w-xs overflow-hidden rounded-xl border border-white/10 shadow-lg">
+                <img
+                  src={heroImage}
+                  alt="Podcast cover art"
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            </div>
           )}
         </div>
       </section>
@@ -166,6 +180,32 @@ function PreviewSection({ website }) {
                   </a>
                 </Button>
               )}
+            </div>
+          )}
+
+          {Array.isArray(layout.section_suggestions) && layout.section_suggestions.length > 0 && (
+            <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-900">Section ideas</h3>
+              <p className="mt-1 text-xs text-slate-500">
+                Toggle your favorites in the builder. Items marked "recommended" are preloaded on the draft.
+              </p>
+              <ul className="mt-4 space-y-3">
+                {layout.section_suggestions.map((suggestion, idx) => (
+                  <li key={idx} className="rounded-md border border-slate-200 bg-white p-3">
+                    <div className="flex items-center justify-between text-sm font-medium text-slate-900">
+                      <span>{suggestion.label || suggestion.type || "Section"}</span>
+                      {suggestion.include_by_default && (
+                        <span className="text-xs font-semibold uppercase tracking-wide" style={{ color: accent }}>
+                          Recommended
+                        </span>
+                      )}
+                    </div>
+                    {suggestion.description && (
+                      <p className="mt-1 text-xs text-slate-500">{suggestion.description}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
         </aside>


### PR DESCRIPTION
## Summary
- derive podcast cover art and color palette to seed website prompts and defaults
- extend AI schema to surface hero imagery plus ~10 curated section suggestions
- surface cover art and section ideas in the dashboard preview with updated tests and dependencies

## Testing
- pytest backend/api/tests/api/test_podcast_websites.py

------
https://chatgpt.com/codex/tasks/task_e_68dc0a4fef088320a45d81d128e96449