### PR TITLE
Skip automation prompts when no intents detected

### DIFF
--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -49,9 +49,10 @@ export default function StepSelectPreprocessed({
   const flubberCount = Number((counts?.flubber?.count) ?? 0);
   const internCount = Number((counts?.intern?.count) ?? 0);
   const sfxCount = Number((counts?.sfx?.count) ?? 0);
+  const hasDetectedAutomations = flubberCount > 0 || internCount > 0 || sfxCount > 0;
 
   const handleContinue = async () => {
-    if (hasPendingIntents && typeof onEditAutomations === 'function') {
+    if (hasDetectedAutomations && hasPendingIntents && typeof onEditAutomations === 'function') {
       onEditAutomations();
       return;
     }
@@ -198,7 +199,7 @@ export default function StepSelectPreprocessed({
         </CardContent>
       </Card>
 
-      {selected && (
+      {selected && hasDetectedAutomations && (
         <Card className="border border-slate-200">
           <CardHeader className="pb-2">
             <CardTitle className="flex items-center gap-2 text-base text-slate-800">


### PR DESCRIPTION
## Summary
- gate the automation modal in the preprocessed audio step behind detected automations
- hide the automation configuration card when no automation cues are present

## Testing
- npm test -- StepSelectPreprocessed *(fails: missing npm script at repo root)*
- (frontend) npm test -- StepSelectPreprocessed *(fails: no matching test files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3f292c1883209041a9a51c501ad7