### PR TITLE
Ensure main content uploads are purged after episode assembly

### DIFF
--- a/tests/test_cleanup_main_content.py
+++ b/tests/test_cleanup_main_content.py
@@ -1,0 +1,44 @@
+from api.core.paths import MEDIA_DIR
+from api.models.podcast import Episode, MediaCategory, MediaItem, Podcast
+from api.models.user import User
+from worker.tasks.assembly.orchestrator import _cleanup_main_content
+
+
+def test_cleanup_main_content_removes_file_and_record(session):
+    user = User(email="cleanup@example.com", hashed_password="hashed")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    podcast = Podcast(name="Cleanup Pod", user_id=user.id)
+    session.add(podcast)
+    session.commit()
+    session.refresh(podcast)
+
+    episode = Episode(user_id=user.id, podcast_id=podcast.id, title="Cleanup Episode")
+    session.add(episode)
+    session.commit()
+    session.refresh(episode)
+
+    filename = "cleanup-test-audio.mp3"
+    file_path = MEDIA_DIR / filename
+    file_path.write_bytes(b"dummy audio data")
+
+    media_item = MediaItem(
+        filename=filename,
+        friendly_name="Cleanup Test",
+        user_id=user.id,
+        category=MediaCategory.main_content,
+    )
+    session.add(media_item)
+    session.commit()
+    session.refresh(media_item)
+
+    _cleanup_main_content(
+        session=session,
+        episode=episode,
+        main_content_filename=filename,
+    )
+
+    assert not file_path.exists()
+    assert session.get(MediaItem, media_item.id) is None


### PR DESCRIPTION
## Summary
- update the assembly cleanup helper to delete main-content uploads from local storage or GCS and remove the database entry once an episode finishes
- add a regression test to confirm the cleanup removes both the file and the media library record

## Testing
- pytest tests/test_cleanup_main_content.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3fa0f0348320bad8b346af6cc74c