### PR TITLE
Ensure transcription watchers trigger notifications

### DIFF
--- a/backend/api/services/transcription/watchers.py
+++ b/backend/api/services/transcription/watchers.py
@@ -1,0 +1,103 @@
+"""Shared helpers for notifying upload watchers."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from sqlmodel import Session, select
+
+from api.core import database as db
+from api.models.notification import Notification
+from api.models.podcast import MediaItem
+from api.models.transcription import TranscriptionWatch
+from api.services.mailer import mailer
+
+log = logging.getLogger("transcription.watchers")
+
+
+def _friendly_name(session: Session, filename: str) -> str:
+    media = session.exec(
+        select(MediaItem).where(MediaItem.filename == filename)
+    ).first()
+    if media and getattr(media, "friendly_name", None):
+        return str(media.friendly_name)
+    return Path(filename).stem or filename
+
+
+def notify_watchers_processed(filename: str) -> None:
+    """Create in-app/email notifications for watchers after transcription."""
+
+    try:
+        with Session(db.engine) as session:
+            stmt = select(TranscriptionWatch).where(
+                TranscriptionWatch.filename == filename,
+                TranscriptionWatch.notified_at == None,  # noqa: E711
+            )
+            watches = session.exec(stmt).all()
+            if not watches:
+                return
+
+            friendly = _friendly_name(session, filename)
+
+            for watch in watches:
+                email = (watch.notify_email or "").strip()
+                status = "pending"
+
+                if email:
+                    subject = "Your upload is ready to edit"
+                    body = (
+                        f"Good news! The audio file '{friendly}' has finished processing and is ready in Podcast Plus Plus.\n\n"
+                        "You can return to the dashboard to continue building your episode."
+                    )
+                    try:
+                        sent = mailer.send(email, subject, body)
+                        status = "sent" if sent else "email-failed"
+                    except Exception:  # pragma: no cover - email best-effort
+                        log.warning("[transcribe] mail send failed for %s", filename, exc_info=True)
+                        status = "email-error"
+                else:
+                    status = "no-email"
+
+                note = Notification(
+                    user_id=watch.user_id,
+                    type="transcription",
+                    title="Upload processed",
+                    body=f"{friendly} is fully transcribed and ready to use.",
+                )
+                session.add(note)
+
+                watch.notified_at = datetime.utcnow()
+                watch.last_status = status
+                session.add(watch)
+
+            session.commit()
+    except Exception:  # pragma: no cover - defensive guardrail
+        log.warning("[transcribe] failed notifying watchers for %s", filename, exc_info=True)
+
+
+def mark_watchers_failed(filename: str, detail: str) -> None:
+    """Record a failure for any outstanding watchers."""
+
+    try:
+        with Session(db.engine) as session:
+            stmt = select(TranscriptionWatch).where(
+                TranscriptionWatch.filename == filename,
+                TranscriptionWatch.notified_at == None,  # noqa: E711
+            )
+            watches = session.exec(stmt).all()
+            if not watches:
+                return
+
+            for watch in watches:
+                watch.last_status = f"error:{detail[:120]}"
+                session.add(watch)
+
+            session.commit()
+    except Exception:  # pragma: no cover - defensive guardrail
+        log.warning("[transcribe] failed recording watcher error for %s", filename, exc_info=True)
+
+
+__all__ = ["notify_watchers_processed", "mark_watchers_failed"]
+

--- a/backend/worker/tasks/transcription.py
+++ b/backend/worker/tasks/transcription.py
@@ -5,86 +5,15 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-from datetime import datetime
 from pathlib import Path
-
-from sqlmodel import Session, select
 
 from .app import celery_app
 from api.core.paths import TRANSCRIPTS_DIR, MEDIA_DIR
-from api.core.database import engine
-from api.models.notification import Notification
-from api.models.podcast import MediaItem
-from api.models.transcription import TranscriptionWatch
-from api.models.user import User
 from api.services import transcription as trans
-from api.services.mailer import mailer
-
-
-def _notify_watchers_processed(filename: str) -> None:
-    try:
-        with Session(engine) as session:
-            stmt = select(TranscriptionWatch).where(
-                TranscriptionWatch.filename == filename,
-                TranscriptionWatch.notified_at == None,  # noqa: E711
-            )
-            watches = session.exec(stmt).all()
-            if not watches:
-                return
-
-            media = session.exec(select(MediaItem).where(MediaItem.filename == filename)).first()
-            friendly = getattr(media, "friendly_name", None) or Path(filename).stem
-
-            for watch in watches:
-                user = session.get(User, watch.user_id)
-                email = (watch.notify_email or getattr(user, "email", "") or "").strip()
-                status = "pending"
-                if email:
-                    subject = "Your upload is ready to edit"
-                    body = (
-                        f"Good news! The audio file '{friendly}' has finished processing and is ready in Podcast Plus Plus.\n\n"
-                        "You can return to the dashboard to continue building your episode."
-                    )
-                    try:
-                        sent = mailer.send(email, subject, body)
-                        status = "sent" if sent else "email-failed"
-                    except Exception:
-                        logging.warning("[transcribe] mail send failed for %s", filename, exc_info=True)
-                        status = "email-error"
-                else:
-                    status = "no-email"
-
-                note = Notification(
-                    user_id=watch.user_id,
-                    type="transcription",
-                    title="Upload processed",
-                    body=f"{friendly} is fully transcribed and ready to use.",
-                )
-                session.add(note)
-                watch.notified_at = datetime.utcnow()
-                watch.last_status = status
-                session.add(watch)
-            session.commit()
-    except Exception:
-        logging.warning("[transcribe] failed notifying watchers for %s", filename, exc_info=True)
-
-
-def _mark_watchers_failed(filename: str, detail: str) -> None:
-    try:
-        with Session(engine) as session:
-            stmt = select(TranscriptionWatch).where(
-                TranscriptionWatch.filename == filename,
-                TranscriptionWatch.notified_at == None,  # noqa: E711
-            )
-            watches = session.exec(stmt).all()
-            if not watches:
-                return
-            for watch in watches:
-                watch.last_status = f"error:{detail[:120]}"
-                session.add(watch)
-            session.commit()
-    except Exception:
-        logging.warning("[transcribe] failed recording watcher error for %s", filename, exc_info=True)
+from api.services.transcription.watchers import (
+    notify_watchers_processed,
+    mark_watchers_failed,
+)
 
 
 @celery_app.task(name="transcribe_media_file")
@@ -167,11 +96,11 @@ def transcribe_media_file(filename: str) -> dict:
             "original": orig_new.name,
             "working": work_new.name,
         }
-        _notify_watchers_processed(filename)
+        notify_watchers_processed(filename)
         return result
     except Exception as exc:
         logging.warning("[transcribe] failed for %s: %s", filename, exc, exc_info=True)
-        _mark_watchers_failed(filename, str(exc))
+        mark_watchers_failed(filename, str(exc))
 
         try:
             if os.getenv("TRANSCRIPTION_FAKE", "").strip().lower() in {
@@ -251,7 +180,7 @@ def transcribe_media_file(filename: str) -> dict:
                     "working": work_new.name,
                     "fake": True,
                 }
-                _notify_watchers_processed(filename)
+                notify_watchers_processed(filename)
                 return result
         except Exception as fallback_exc:
             logging.warning(

--- a/tests/test_media_upload_notifications.py
+++ b/tests/test_media_upload_notifications.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Tuple
+
+import pytest
+from sqlmodel import select
+
+from api.core.security import get_password_hash
+from api.core.paths import MEDIA_DIR
+from api.models.notification import Notification
+from api.models.podcast import MediaCategory, MediaItem
+from api.models.transcription import TranscriptionWatch
+from api.models.user import User
+from api.services.transcription import transcribe_media_file
+
+
+def _create_user(session) -> Tuple[User, str]:
+    password = "notify-me!123"
+    user = User(
+        email="notify-tester@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user, password
+
+
+def _auth_headers(client, email: str, password: str) -> dict[str, str]:
+    response = client.post(
+        "/api/auth/token",
+        data={"username": email, "password": password},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.usefixtures("db_engine")
+def test_main_content_upload_records_watch_without_email(session, client, monkeypatch):
+    user, password = _create_user(session)
+    headers = _auth_headers(client, user.email, password)
+
+    stub_task = lambda path, body: {"name": "stubbed"}
+    monkeypatch.setattr(
+        "infrastructure.tasks_client.enqueue_http_task",
+        stub_task,
+    )
+    monkeypatch.setattr(
+        "backend.api.routers.media.write.enqueue_http_task",
+        stub_task,
+    )
+
+    resp = client.post(
+        "/api/media/upload/main_content",
+        data={
+            "notify_when_ready": "false",
+            "friendly_names": json.dumps(["My Upload"]),
+        },
+        files={
+            "files": ("sample.wav", io.BytesIO(b"RIFF....WAVE"), "audio/wav"),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert isinstance(payload, list) and payload
+
+    filename = payload[0]["filename"]
+    watch = session.exec(
+        select(TranscriptionWatch).where(
+            TranscriptionWatch.user_id == user.id,
+            TranscriptionWatch.filename == filename,
+        )
+    ).first()
+
+    assert watch is not None
+    assert (watch.notify_email or "").strip() == ""
+    assert watch.last_status == "queued"
+
+
+@pytest.mark.usefixtures("db_engine")
+def test_main_content_upload_records_email_target(session, client, monkeypatch):
+    user, password = _create_user(session)
+    headers = _auth_headers(client, user.email, password)
+
+    stub_task = lambda path, body: {"name": "stubbed"}
+    monkeypatch.setattr(
+        "infrastructure.tasks_client.enqueue_http_task",
+        stub_task,
+    )
+    monkeypatch.setattr(
+        "backend.api.routers.media.write.enqueue_http_task",
+        stub_task,
+    )
+
+    notify_email = "alerts@example.com"
+    resp = client.post(
+        "/api/media/upload/main_content",
+        data={
+            "notify_when_ready": "true",
+            "notify_email": notify_email,
+        },
+        files={
+            "files": ("another.wav", io.BytesIO(b"RIFF....WAVE"), "audio/wav"),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert isinstance(payload, list) and payload
+
+    filename = payload[0]["filename"]
+    watch = session.exec(
+        select(TranscriptionWatch).where(
+            TranscriptionWatch.user_id == user.id,
+            TranscriptionWatch.filename == filename,
+        )
+    ).first()
+
+    assert watch is not None
+    assert watch.notify_email == notify_email
+    assert watch.last_status == "queued"
+
+
+@pytest.mark.usefixtures("db_engine")
+def test_transcribe_media_file_notifies_watchers_with_email(session, monkeypatch):
+    user, _ = _create_user(session)
+
+    filename = "notify-me.wav"
+    friendly = "Notify Me"
+    (MEDIA_DIR / filename).write_bytes(b"RIFF....WAVE")
+
+    media_item = MediaItem(
+        filename=filename,
+        friendly_name=friendly,
+        user_id=user.id,
+        category=MediaCategory.main_content,
+    )
+    session.add(media_item)
+    watch = TranscriptionWatch(
+        user_id=user.id,
+        filename=filename,
+        friendly_name=friendly,
+        notify_email="alerts@example.com",
+        last_status="queued",
+    )
+    session.add(watch)
+    session.commit()
+
+    sent: list[tuple[str, str, str]] = []
+
+    def fake_send(email: str, subject: str, body: str) -> bool:
+        sent.append((email, subject, body))
+        return True
+
+    monkeypatch.setattr("api.services.transcription.watchers.mailer.send", fake_send)
+    monkeypatch.setattr(
+        "api.services.transcription.get_word_timestamps",
+        lambda _: [{"word": "ok", "start": 0.0, "end": 0.5}],
+    )
+
+    transcribe_media_file(filename)
+
+    updated_watch = session.exec(
+        select(TranscriptionWatch).where(
+            TranscriptionWatch.user_id == user.id,
+            TranscriptionWatch.filename == filename,
+        )
+    ).first()
+    assert updated_watch is not None
+    assert updated_watch.notified_at is not None
+    assert updated_watch.last_status == "sent"
+
+    notes = session.exec(
+        select(Notification).where(Notification.user_id == user.id)
+    ).all()
+    assert len(notes) == 1
+    assert friendly in notes[0].body
+    assert sent and sent[0][0] == "alerts@example.com"
+
+
+@pytest.mark.usefixtures("db_engine")
+def test_transcribe_media_file_notifies_without_email(session, monkeypatch):
+    user, _ = _create_user(session)
+
+    filename = "notify-none.wav"
+    friendly = "Notify None"
+    (MEDIA_DIR / filename).write_bytes(b"RIFF....WAVE")
+
+    session.add(
+        MediaItem(
+            filename=filename,
+            friendly_name=friendly,
+            user_id=user.id,
+            category=MediaCategory.main_content,
+        )
+    )
+    session.add(
+        TranscriptionWatch(
+            user_id=user.id,
+            filename=filename,
+            friendly_name=friendly,
+            notify_email=None,
+            last_status="queued",
+        )
+    )
+    session.commit()
+
+    sent: list[tuple[str, str, str]] = []
+
+    def fake_send(email: str, subject: str, body: str) -> bool:
+        sent.append((email, subject, body))
+        return True
+
+    monkeypatch.setattr("api.services.transcription.watchers.mailer.send", fake_send)
+    monkeypatch.setattr(
+        "api.services.transcription.get_word_timestamps",
+        lambda _: [{"word": "ok", "start": 0.0, "end": 0.5}],
+    )
+
+    transcribe_media_file(filename)
+
+    updated_watch = session.exec(
+        select(TranscriptionWatch).where(
+            TranscriptionWatch.user_id == user.id,
+            TranscriptionWatch.filename == filename,
+        )
+    ).first()
+    assert updated_watch is not None
+    assert updated_watch.notified_at is not None
+    assert updated_watch.last_status == "no-email"
+
+    notes = session.exec(
+        select(Notification).where(Notification.user_id == user.id)
+    ).all()
+    assert len(notes) == 1
+    assert friendly in notes[0].body
+    assert sent == []


### PR DESCRIPTION
## Summary
- ensure the API transcription service notifies watchers on success and records failures when transcription jobs error
- share notification helper logic between the API and worker so in-app and optional email alerts fire consistently
- extend upload notification tests to cover transcription completion with and without an email request

## Testing
- pytest tests/test_media_upload_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3d8e62308320a56a9090ecd49449