### PR TITLE
Disable DirectPath for Google Speech client

### DIFF
--- a/backend/api/services/transcription_google.py
+++ b/backend/api/services/transcription_google.py
@@ -3,6 +3,14 @@ import os
 from pathlib import Path
 from typing import List, Dict, Any
 
+# ``google-cloud-speech`` attempts to negotiate ALTS credentials automatically
+# when DirectPath is enabled.  Outside of Google Cloud this results in noisy
+# "untrusted ALTS is not enabled" log messages and can block requests in some
+# environments.  Disable DirectPath pre-emptively so that the client falls back
+# to standard TLS everywhere.
+os.environ.setdefault("GOOGLE_CLOUD_ENABLE_DIRECT_PATH", "0")
+os.environ.setdefault("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "0")
+
 CHUNK_DURATION_MS = 10 * 60 * 1000  # reuse chunk size
 
 try:


### PR DESCRIPTION
## Summary
- disable Google Cloud DirectPath in the Google Speech transcription helper to avoid ALTS credential errors outside GCP environments

## Testing
- pytest tests/test_transcription_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc31047c88320ba100f13cad04973