### PR TITLE
Streamline template editor workflow

### DIFF
--- a/frontend/src/components/dashboard/RecurringScheduleManager.jsx
+++ b/frontend/src/components/dashboard/RecurringScheduleManager.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChevronDown } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -64,6 +65,8 @@ export default function RecurringScheduleManager({
   userTimezone,
   isNewTemplate,
   onDirtyChange,
+  collapsible = false,
+  defaultOpen = true,
 }) {
   const deviceTimezone = useMemo(() => detectDeviceTimezone(userTimezone || 'UTC'), [userTimezone]);
   const [loading, setLoading] = useState(false);
@@ -75,6 +78,12 @@ export default function RecurringScheduleManager({
   const [timeInput, setTimeInput] = useState('05:00');
   const [daySelection, setDaySelection] = useState(() => new Set([0]));
   const [baseline, setBaseline] = useState({ timezone: deviceTimezone, slots: [] });
+
+  const [isOpen, setIsOpen] = useState(!collapsible || defaultOpen);
+
+  useEffect(() => {
+    setIsOpen(!collapsible || defaultOpen);
+  }, [collapsible, defaultOpen]);
 
   useEffect(() => {
     if (typeof onDirtyChange === 'function') {
@@ -250,30 +259,63 @@ export default function RecurringScheduleManager({
   if (!templateId || templateId === 'new' || isNewTemplate) {
     return (
       <Card className="shadow-sm">
-        <CardHeader>
-          <CardTitle>Recurring Publish Schedule</CardTitle>
-          <CardDescription>Save your template first to plan automatic publish slots.</CardDescription>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>Recurring Publish Schedule</CardTitle>
+            <CardDescription>Save your template first to plan automatic publish slots.</CardDescription>
+          </div>
+          {collapsible && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mt-2 h-8 px-2 text-slate-600 sm:mt-0"
+              onClick={() => setIsOpen((prev) => !prev)}
+              aria-expanded={isOpen}
+            >
+              <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+              <span className="sr-only">Toggle schedule details</span>
+            </Button>
+          )}
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Once this template is saved, you can choose the days and times it should publish automatically. Each new episode will
-            pick the next open slot.
-          </p>
-        </CardContent>
+        {(!collapsible || isOpen) && (
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Once this template is saved, you can choose the days and times it should publish automatically. Each new episode will
+              pick the next open slot.
+            </p>
+          </CardContent>
+        )}
       </Card>
     );
   }
 
   return (
     <Card className="shadow-sm">
-      <CardHeader>
-        <CardTitle>Recurring Publish Schedule</CardTitle>
-        <CardDescription>
-          Tell Plus Plus when episodes made from this template should go live. We&rsquo;ll skip conflicts with already scheduled
-          episodes.
-        </CardDescription>
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle>Recurring Publish Schedule</CardTitle>
+          <CardDescription>
+            Tell Plus Plus when episodes made from this template should go live. We&rsquo;ll skip conflicts with already scheduled
+            episodes.
+          </CardDescription>
+        </div>
+        {collapsible && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-2 h-8 px-2 text-slate-600 sm:mt-0"
+            onClick={() => setIsOpen((prev) => !prev)}
+            aria-expanded={isOpen}
+          >
+            <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+            <span className="sr-only">Toggle schedule details</span>
+          </Button>
+        )}
       </CardHeader>
-      <CardContent className="space-y-6">
+      {(!collapsible || isOpen) && (
+        <CardContent className="space-y-6">
         {error && <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
 
         <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
@@ -409,7 +451,8 @@ export default function RecurringScheduleManager({
             </Button>
           </div>
         </div>
-      </CardContent>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/frontend/src/components/dashboard/TemplateAIContent.jsx
+++ b/frontend/src/components/dashboard/TemplateAIContent.jsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useEffect } from "react";
  * Lightweight AI Content section for TemplateEditor.
  * No external UI lib required; uses your page's base styles.
  */
-export default function TemplateAIContent({ value, onChange }) {
+export default function TemplateAIContent({ value, onChange, className = "" }) {
   const v = value || { auto_fill_ai: true, title_instructions: "", notes_instructions: "", tags_instructions: "", tags_always_include: [], auto_generate_tags: true };
   const tagsAlwaysStr = useMemo(() => (v.tags_always_include || []).join(", "), [v.tags_always_include]);
   // Local input state so users can type spaces inside a tag without it being trimmed mid-typing
@@ -34,41 +34,41 @@ export default function TemplateAIContent({ value, onChange }) {
   const set = (patch) => onChange?.({ ...v, ...patch });
 
   return (
-    <section className="space-y-3 border rounded-md p-3 mt-6">
-      <div className="flex items-center justify-between">
-        <h2 className="font-medium">AI Content</h2>
-        <label className="inline-flex items-center gap-2 text-sm">
+    <div className={`space-y-4 ${className}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-base font-semibold text-slate-800">AI Content defaults</h3>
+        <label className="inline-flex items-center gap-2 text-sm text-slate-700">
           <input type="checkbox" checked={!!v.auto_fill_ai} onChange={(e)=> set({ auto_fill_ai: !!e.target.checked })} />
           <span>Auto fill fields with AI suggestions?</span>
         </label>
       </div>
 
       <div className="space-y-1">
-        <label className="text-sm font-medium">Title instructions</label>
-        <textarea className="w-full border rounded px-3 py-2" rows={3}
+        <label className="text-sm font-medium text-slate-700">Title instructions</label>
+        <textarea className="w-full rounded border border-slate-300 px-3 py-2" rows={3}
           placeholder='e.g., Use format "E### – Film – Hook". Keep ≤ 80 chars.'
           value={v.title_instructions || ""}
           onChange={(e)=> set({ title_instructions: e.target.value })} />
       </div>
 
       <div className="space-y-1">
-        <label className="text-sm font-medium">Notes/Description instructions</label>
-        <textarea className="w-full border rounded px-3 py-2" rows={4}
+        <label className="text-sm font-medium text-slate-700">Notes/Description instructions</label>
+        <textarea className="w-full rounded border border-slate-300 px-3 py-2" rows={4}
           placeholder='e.g., Snarky tone. Provide time-stamped overview of major points.'
           value={v.notes_instructions || ""}
           onChange={(e)=> set({ notes_instructions: e.target.value })} />
       </div>
 
       <div className="space-y-1">
-        <label className="text-sm font-medium">Tags instructions (optional)</label>
-        <textarea className="w-full border rounded px-3 py-2" rows={3}
+        <label className="text-sm font-medium text-slate-700">Tags instructions (optional)</label>
+        <textarea className="w-full rounded border border-slate-300 px-3 py-2" rows={3}
           placeholder='e.g., Focus on movie, director, year. No spoilers in tags.'
           value={v.tags_instructions || ""}
           onChange={(e)=> set({ tags_instructions: e.target.value })} />
       </div>
 
       <div className="space-y-1">
-        <label className="inline-flex items-center gap-2 text-sm">
+        <label className="inline-flex items-center gap-2 text-sm text-slate-700">
           <input
             type="checkbox"
             checked={v.auto_generate_tags === false}
@@ -80,8 +80,8 @@ export default function TemplateAIContent({ value, onChange }) {
       </div>
 
       <div className="space-y-1">
-        <label className="text-sm font-medium">Always include these tags (comma-separated)</label>
-        <input className="w-full border rounded px-3 py-2"
+        <label className="text-sm font-medium text-slate-700">Always include these tags (comma-separated)</label>
+        <input className="w-full rounded border border-slate-300 px-3 py-2"
           placeholder="e.g., star wars, podcast, film"
           value={tagsInput}
           onChange={(e)=> {
@@ -98,6 +98,6 @@ export default function TemplateAIContent({ value, onChange }) {
         />
         <p className="text-xs text-muted-foreground">We’ll add these first, then the AI fills the rest (max 20 total; each ≤ 30 chars).</p>
       </div>
-    </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- move AI guidance into its own collapsible card and restyle the AI content form for consistency
- collapse the Episode Structure tools into a single row with add-segment buttons beside the draggable order list and slim segment cards
- rename Advanced options to Music & Timing Options, keep those controls collapsible, and allow the recurring schedule card to collapse

## Testing
- npm run lint -- --max-warnings=0 *(fails: repository already has unused eslint-disable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd2ddb6088320b6321ca78c4d8dc1