### PR TITLE
Fix worker media resolution for uploader sanitized filenames

### DIFF
--- a/tests/worker/test_media_resolution.py
+++ b/tests/worker/test_media_resolution.py
@@ -43,3 +43,20 @@ def test_resolve_media_returns_existing_media(tmp_path):
 
     assert resolved == target
     assert resolved.read_bytes() == b"audio"
+
+
+def test_resolve_media_handles_uploader_sanitization(tmp_path):
+    """Filenames saved by the upload endpoint preserve casing and use underscores."""
+
+    from backend.worker.tasks.assembly import media as media_module
+
+    original_name = "Demo Episode: What's New?.mp3"
+    sanitized = "Demo_Episode__What_s_New_.mp3"
+
+    durable = media_module.MEDIA_DIR / sanitized
+    durable.write_bytes(b"durable")
+
+    resolved = media_module._resolve_media_file(original_name)
+
+    assert resolved == durable
+    assert resolved.read_bytes() == b"durable"


### PR DESCRIPTION
## Summary
- align the worker media resolver with the upload endpoint's underscore-based filename sanitization so durable copies are reused
- add regression coverage ensuring underscore-sanitized filenames resolve from MEDIA_DIR

## Testing
- pytest tests/worker/test_media_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68dd725147f88320bf4334e27a6bb204