### PR TITLE
Add minutes precheck flow to podcast creator

### DIFF
--- a/backend/api/routers/episodes/__init__.py
+++ b/backend/api/routers/episodes/__init__.py
@@ -7,6 +7,7 @@ router = APIRouter(prefix="/episodes", tags=["episodes"])
 from .read import router as read_router
 from .write import router as write_router
 from .assemble import router as assemble_router
+from .precheck import router as precheck_router
 from .publish import router as publish_router
 from .jobs import router as jobs_router
 from .edit import router as edit_router
@@ -19,6 +20,7 @@ from .retry import router as retry_router
 # runtime startup. By including the assemble router first we ensure POST
 # requests hit the intended handler instead of returning an unexpected 405.
 router.include_router(assemble_router)
+router.include_router(precheck_router)
 router.include_router(read_router)
 router.include_router(write_router)
 router.include_router(publish_router)

--- a/backend/api/routers/episodes/precheck.py
+++ b/backend/api/routers/episodes/precheck.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from api.core.database import get_session
+from api.models.user import User
+from api.routers.auth import get_current_user
+from api.services.episodes import assembler as _svc_assembler
+
+router = APIRouter(tags=["episodes"])  # parent provides '/episodes' prefix
+log = logging.getLogger("ppp.episodes.precheck")
+
+
+@router.post("/precheck/minutes", status_code=status.HTTP_200_OK)
+async def precheck_minutes(
+    payload: Dict[str, Any],
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    template_id = payload.get("template_id")
+    main_content_filename = payload.get("main_content_filename")
+
+    if not template_id or not main_content_filename:
+        raise HTTPException(status_code=400, detail="template_id and main_content_filename are required.")
+
+    try:
+        return _svc_assembler.minutes_precheck(
+            session=session,
+            current_user=current_user,
+            template_id=str(template_id),
+            main_content_filename=str(main_content_filename),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        log.exception("minutes precheck failed")
+        raise HTTPException(status_code=500, detail="Failed to evaluate minutes precheck.")

--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -127,6 +127,12 @@ export default function PodcastCreator({
     usage,
     minutesNearCap,
     minutesRemaining,
+    minutesPrecheck,
+    minutesPrecheckPending,
+    minutesPrecheckError,
+    minutesBlocking,
+    minutesRequiredPrecheck,
+    minutesRemainingPrecheck,
     minutesDialog,
     setMinutesDialog,
     activeSegment,
@@ -231,6 +237,9 @@ export default function PodcastCreator({
     return parts.join(' ');
   };
 
+  const minutesBlockingMessage = minutesPrecheck?.detail?.message
+    || (minutesBlocking ? 'Not enough processing minutes remain to assemble this episode.' : '');
+
   const minutesDialogDuration = minutesDialog?.durationSeconds != null
     ? formatDuration(minutesDialog.durationSeconds)
     : (minutesDialog?.requiredMinutes ? formatDuration(minutesDialog.requiredMinutes * 60) : null);
@@ -280,11 +289,20 @@ export default function PodcastCreator({
               onNext={() => setCurrentStep(3)}
               onRefresh={onRefreshPreuploaded}
               intents={intents}
-              pendingIntentLabels={pendingIntentLabels}
-              onIntentSubmit={handleIntentSubmit}
-              onEditAutomations={() => setShowIntentQuestions(true)}
-              onDeleteItem={handleDeletePreuploaded}
-            />
+            pendingIntentLabels={pendingIntentLabels}
+            onIntentSubmit={handleIntentSubmit}
+            onEditAutomations={() => setShowIntentQuestions(true)}
+            onDeleteItem={handleDeletePreuploaded}
+            minutesPrecheck={minutesPrecheck}
+            minutesPrecheckPending={minutesPrecheckPending}
+            minutesPrecheckError={minutesPrecheckError}
+            minutesBlocking={minutesBlocking}
+            minutesBlockingMessage={minutesBlockingMessage}
+            minutesRequired={minutesRequiredPrecheck}
+            minutesRemaining={minutesRemainingPrecheck}
+            formatDuration={formatDuration}
+            audioDurationSec={audioDurationSec}
+          />
           );
         }
         return (
@@ -303,6 +321,15 @@ export default function PodcastCreator({
             pendingIntentLabels={pendingIntentLabels}
             intents={intents}
             intentVisibility={intentVisibility}
+            minutesPrecheck={minutesPrecheck}
+            minutesPrecheckPending={minutesPrecheckPending}
+            minutesPrecheckError={minutesPrecheckError}
+            minutesBlocking={minutesBlocking}
+            minutesBlockingMessage={minutesBlockingMessage}
+            minutesRequired={minutesRequiredPrecheck}
+            minutesRemaining={minutesRemainingPrecheck}
+            formatDuration={formatDuration}
+            audioDurationSec={audioDurationSec}
           />
         );
       case 3:
@@ -377,6 +404,15 @@ export default function PodcastCreator({
             onPublishVisibilityChange={setPublishVisibility}
             onScheduleDateChange={setScheduleDate}
             onScheduleTimeChange={setScheduleTime}
+            minutesPrecheck={minutesPrecheck}
+            minutesPrecheckPending={minutesPrecheckPending}
+            minutesPrecheckError={minutesPrecheckError}
+            minutesBlocking={minutesBlocking}
+            minutesBlockingMessage={minutesBlockingMessage}
+            minutesRequired={minutesRequiredPrecheck}
+            minutesRemaining={minutesRemainingPrecheck}
+            formatDuration={formatDuration}
+            audioDurationSec={audioDurationSec}
           />
         );
       case 6:

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -15,7 +15,7 @@ const formatDate = (iso) => {
   }
 };
 
-const formatDuration = (seconds) => {
+const formatItemDuration = (seconds) => {
   if (!seconds || !isFinite(seconds)) return '—';
   const mins = Math.floor(seconds / 60);
   const secs = Math.round(seconds % 60);
@@ -37,6 +37,15 @@ export default function StepSelectPreprocessed({
   onIntentSubmit,
   onEditAutomations,
   onDeleteItem = null,
+  minutesPrecheck = null,
+  minutesPrecheckPending = false,
+  minutesPrecheckError = null,
+  minutesBlocking = false,
+  minutesBlockingMessage = '',
+  minutesRequired = null,
+  minutesRemaining = null,
+  formatDuration = () => null,
+  audioDurationSec = null,
 }) {
   const hasPendingIntents = Array.isArray(pendingIntentLabels) && pendingIntentLabels.length > 0;
 
@@ -65,6 +74,31 @@ export default function StepSelectPreprocessed({
   };
 
   const canContinue = !!selected;
+
+  const formatDurationSafe = typeof formatDuration === 'function' ? formatDuration : () => null;
+  const parseNumber = (value) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  };
+  const totalSeconds = parseNumber(minutesPrecheck?.total_seconds);
+  const staticSeconds = parseNumber(minutesPrecheck?.static_seconds);
+  const mainSeconds = parseNumber(minutesPrecheck?.main_seconds);
+  const requiredMinutesVal = parseNumber(minutesRequired);
+  const remainingMinutesVal = parseNumber(minutesRemaining);
+  const audioDurationText = audioDurationSec ? formatDurationSafe(audioDurationSec) : null;
+  const totalDurationText = totalSeconds
+    ? formatDurationSafe(totalSeconds)
+    : (mainSeconds ? formatDurationSafe(mainSeconds) : audioDurationText);
+  const staticDurationText = staticSeconds ? formatDurationSafe(staticSeconds) : null;
+  const requiredMinutesText = requiredMinutesVal != null
+    ? `${requiredMinutesVal} minute${requiredMinutesVal === 1 ? '' : 's'}`
+    : null;
+  const remainingMinutesDisplay = remainingMinutesVal != null ? Math.max(0, remainingMinutesVal) : null;
+  const remainingMinutesText = remainingMinutesDisplay != null
+    ? `${remainingMinutesDisplay} minute${remainingMinutesDisplay === 1 ? '' : 's'}`
+    : null;
+  const showPrecheckCard = !!selected && (minutesPrecheckPending || minutesPrecheck || minutesPrecheckError);
+  const blockingMessage = minutesBlockingMessage || 'Not enough processing minutes remain to assemble this episode.';
 
   return (
     <div className="space-y-6">
@@ -168,7 +202,7 @@ export default function StepSelectPreprocessed({
                             )}
                           </div>
                           <div className="text-xs text-slate-500">
-                            Uploaded {formatDate(item.created_at)} · Duration {formatDuration(item.duration_seconds)}
+                            Uploaded {formatDate(item.created_at)} · Duration {formatItemDuration(item.duration_seconds)}
                           </div>
                           {ready && (
                             <div className="flex flex-wrap gap-2 mt-2 text-xs text-slate-600">
@@ -198,6 +232,47 @@ export default function StepSelectPreprocessed({
           </div>
         </CardContent>
       </Card>
+
+      {showPrecheckCard && (
+        <div
+          className={`rounded-md border p-4 text-sm ${minutesBlocking ? 'border-red-300 bg-red-50 text-red-700' : 'border-slate-200 bg-slate-50 text-slate-700'}`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-semibold">Processing minutes check</span>
+            {minutesPrecheckPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : minutesBlocking ? (
+              <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+            ) : null}
+          </div>
+          <div className="mt-2 space-y-2">
+            {minutesPrecheckPending && <p>Checking your remaining processing minutes…</p>}
+            {!minutesPrecheckPending && minutesPrecheckError && (
+              <p className="text-amber-700">{minutesPrecheckError}</p>
+            )}
+            {!minutesPrecheckPending && !minutesPrecheckError && (
+              <>
+                <p>{minutesBlocking ? blockingMessage : 'This episode fits within your available processing minutes.'}</p>
+                {totalDurationText && (
+                  <p>
+                    Estimated length <strong>{totalDurationText}</strong>
+                    {staticDurationText ? ` (template adds ${staticDurationText})` : ''}.
+                  </p>
+                )}
+                {!totalDurationText && audioDurationText && (
+                  <p>Uploaded audio length <strong>{audioDurationText}</strong>.</p>
+                )}
+                {requiredMinutesText && (
+                  <p>Requires <strong>{requiredMinutesText}</strong> of processing time.</p>
+                )}
+                {remainingMinutesText && (
+                  <p>Your plan has <strong>{remainingMinutesText}</strong> remaining.</p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       {selected && hasDetectedAutomations && (
         <Card className="border border-slate-200">
@@ -245,13 +320,24 @@ export default function StepSelectPreprocessed({
         </Card>
       )}
 
-      <div className="flex justify-between pt-4">
+      <div className="flex justify-between pt-4 items-start">
         <Button variant="ghost" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={!canContinue || loading}>
-          Continue
-        </Button>
+        <div className="flex flex-col items-end gap-1">
+          <Button
+            onClick={handleContinue}
+            disabled={!canContinue || loading || minutesPrecheckPending || minutesBlocking}
+          >
+            Continue
+          </Button>
+          {minutesPrecheckPending && (
+            <span className="text-xs text-slate-600">Waiting for processing minutes check…</span>
+          )}
+          {minutesBlocking && !minutesPrecheckPending && (
+            <span className="text-xs text-red-600">{blockingMessage}</span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/tests/test_minutes_precheck.py
+++ b/tests/test_minutes_precheck.py
@@ -1,0 +1,74 @@
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from api.services.episodes import assembler
+
+
+def _make_template():
+    return SimpleNamespace(
+        segments_json=json.dumps(
+            [
+                {"segment_type": "intro", "source": {"source_type": "static", "filename": "intro.mp3"}},
+                {"segment_type": "content", "source": {"source_type": "static", "filename": "content.mp3"}},
+                {"segment_type": "outro", "source": {"source_type": "static", "filename": "outro.mp3"}},
+            ]
+        )
+    )
+
+
+def _duration_stub(name_map):
+    def _inner(filename):
+        key = str(filename).split("/")[-1]
+        return name_map.get(key)
+
+    return _inner
+
+
+def test_minutes_precheck_allows(monkeypatch):
+    user = SimpleNamespace(id=uuid4(), tier="creator", subscription_expires_at=None)
+    template = _make_template()
+
+    monkeypatch.setattr(assembler.repo, "get_template_by_id", lambda session, tid: template)
+    monkeypatch.setattr(assembler.usage_svc, "month_minutes_used", lambda *args, **kwargs: 30)
+    durations = {"content.mp3": 600.0, "intro.mp3": 45.0, "outro.mp3": 30.0}
+    monkeypatch.setattr(assembler, "_estimate_audio_seconds", _duration_stub(durations))
+
+    result = assembler.minutes_precheck(
+        session=None,
+        current_user=user,
+        template_id=str(uuid4()),
+        main_content_filename="content.mp3",
+    )
+
+    assert result["allowed"] is True
+    assert result["minutes_required"] == 12
+    assert pytest.approx(result["static_seconds"], rel=1e-6) == durations["intro.mp3"] + durations["outro.mp3"]
+    remaining = assembler.TIER_LIMITS["creator"]["max_processing_minutes_month"] - 30
+    assert result["minutes_remaining"] == remaining
+
+
+def test_minutes_precheck_blocks_when_over(monkeypatch):
+    user = SimpleNamespace(id=uuid4(), tier="free", subscription_expires_at=None)
+    template = _make_template()
+
+    monkeypatch.setattr(assembler.repo, "get_template_by_id", lambda session, tid: template)
+    monkeypatch.setattr(assembler.usage_svc, "month_minutes_used", lambda *args, **kwargs: 55)
+    durations = {"content.mp3": 900.0, "intro.mp3": 60.0, "outro.mp3": 45.0}
+    monkeypatch.setattr(assembler, "_estimate_audio_seconds", _duration_stub(durations))
+
+    result = assembler.minutes_precheck(
+        session=None,
+        current_user=user,
+        template_id=str(uuid4()),
+        main_content_filename="content.mp3",
+    )
+
+    assert result["allowed"] is False
+    detail = result.get("detail") or {}
+    assert detail.get("code") == "INSUFFICIENT_MINUTES"
+    assert detail.get("source") == "precheck"
+    assert detail.get("minutes_required") == result["minutes_required"]
+    assert detail.get("minutes_remaining") == max(0, result["minutes_remaining"])


### PR DESCRIPTION
## Summary
- add a backend minutes precheck service and router to evaluate processing usage allowances before assembling an episode
- wire the podcast creator UI to call the minutes precheck, surfacing warnings and blocking progression when quotas are exceeded
- cover the new minutes precheck logic with focused unit tests

## Testing
- pytest tests/test_minutes_precheck.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8507c8d08320a83b2fe0949d3093