### PR TITLE
Streamline episode start flow

### DIFF
--- a/frontend/src/components/dashboard.jsx
+++ b/frontend/src/components/dashboard.jsx
@@ -458,10 +458,6 @@ export default function PodcastPlusDashboard() {
               }
               setCurrentView('createEpisode');
             }}
-            onChooseRecord={() => {
-              setCreatorMode('standard');
-              setCurrentView('recorder');
-            }}
           />
         );
       }
@@ -493,6 +489,10 @@ export default function PodcastPlusDashboard() {
             preuploadedLoading={preuploadLoading}
             onRefreshPreuploaded={refreshPreuploads}
             preselectedStartStep={creatorMode === 'preuploaded' ? 1 : undefined}
+            onRequestUpload={() => {
+              setCreatorMode('standard');
+              setCurrentView('preuploadUpload');
+            }}
           />
         );
       case 'mediaLibrary':

--- a/frontend/src/components/dashboard/EpisodeStartOptions.jsx
+++ b/frontend/src/components/dashboard/EpisodeStartOptions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui/card';
-import { AlertTriangle, ArrowLeft, Library, Mic, Upload } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Library, Upload } from 'lucide-react';
 import styles from './EpisodeStartOptions.module.css';
 
 export default function EpisodeStartOptions({
@@ -12,7 +12,6 @@ export default function EpisodeStartOptions({
   onBack,
   onChooseUpload,
   onChooseLibrary,
-  onChooseRecord,
 }) {
   return (
     <div className="space-y-6">
@@ -28,10 +27,10 @@ export default function EpisodeStartOptions({
         <CardHeader>
           <CardTitle className="text-2xl" style={{ color: '#2C3E50' }}>How do you want to start?</CardTitle>
           <CardDescription className="text-slate-600 text-sm">
-            Upload new audio to process in the background, pick from your finished uploads, or record right now.
+            Upload fresh audio or jump straight into picking a processed file that’s ready to edit.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
+        <CardContent className="grid gap-4 md:grid-cols-2">
           <button
             type="button"
             onClick={onChooseUpload}
@@ -44,45 +43,26 @@ export default function EpisodeStartOptions({
             </p>
           </button>
 
-          <div className={`relative ${!hasReadyAudio ? 'group' : ''}`}>
+          <div className="border border-emerald-200 rounded-xl text-left hover:border-emerald-500 hover:shadow-sm transition relative">
             <button
               type="button"
-              onClick={hasReadyAudio ? onChooseLibrary : undefined}
-              disabled={!hasReadyAudio || loading}
-              title={!hasReadyAudio ? 'You must upload audio first' : undefined}
-              className={`border rounded-xl text-left transition ${
-                hasReadyAudio
-                  ? 'border-emerald-200 hover:border-emerald-500 hover:shadow-sm'
-                  : 'border-slate-200 bg-slate-100 cursor-not-allowed text-slate-400'
-              } ${styles['uniform-card']}`}
+              onClick={onChooseLibrary}
+              disabled={loading}
+              className={`${styles['uniform-card']} w-full text-left ${loading ? 'opacity-90 cursor-wait' : ''}`}
             >
               <Library className={`w-6 h-6 mb-4 ${hasReadyAudio ? 'text-emerald-500' : 'text-slate-400'}`} />
-              <div className="font-semibold text-slate-800 mb-1">Use processed audio</div>
+              <div className="font-semibold text-slate-800 mb-1">Upload and use processed audio</div>
               <p className="text-sm text-slate-600">
-                Jump straight into editing with transcripts and automations ready. {hasReadyAudio ? '' : 'Upload audio first and we will unlock this option.'}
+                Jump straight into Step 2 to pick a processed upload or add a new file. {hasReadyAudio ? '' : 'If you haven’t uploaded anything yet, we’ll guide you there.'}
               </p>
             </button>
 
             {!hasReadyAudio && (
-              <div className="absolute left-0 -bottom-2 translate-y-full z-10 hidden group-hover:block">
-                <div className="max-w-xs rounded-md border border-red-200 bg-white shadow-md p-2">
-                  <span className="text-sm text-red-600">You must upload audio first</span>
-                </div>
+              <div className="px-4 pb-4 text-xs text-amber-700">
+                You’ll need at least one processed upload before you can continue, but we’ll show you how to add one.
               </div>
             )}
           </div>
-
-          <button
-            type="button"
-            onClick={onChooseRecord}
-            className={`border border-slate-200 rounded-xl text-left hover:border-purple-400 hover:shadow-sm transition ${styles['uniform-card']}`}
-          >
-            <Mic className="w-6 h-6 text-purple-500 mb-4" />
-            <div className="font-semibold text-slate-800 mb-1">Record your show</div>
-            <p className="text-sm text-slate-600">
-              Capture your episode now. Once the recording finishes we’ll process it just like an upload and alert you when it’s ready.
-            </p>
-          </button>
         </CardContent>
       </Card>
 

--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -33,6 +33,7 @@ export default function PodcastCreator({
   preuploadedLoading = false,
   onRefreshPreuploaded = () => {},
   preselectedStartStep,
+  onRequestUpload,
 }) {
   const controller = usePodcastCreator({
     token,
@@ -144,6 +145,18 @@ export default function PodcastCreator({
   } = controller;
 
   const { toast } = useToast();
+
+  const autoAdvanceRef = React.useRef(false);
+  React.useEffect(() => {
+    if (creatorMode === 'preuploaded') {
+      if (!autoAdvanceRef.current && currentStep === 1) {
+        setCurrentStep(2);
+        autoAdvanceRef.current = true;
+      }
+    } else {
+      autoAdvanceRef.current = false;
+    }
+  }, [creatorMode, currentStep, setCurrentStep]);
 
   const selectedPreuploadItem = React.useMemo(
     () => {
@@ -284,6 +297,7 @@ export default function PodcastCreator({
               onIntentSubmit={handleIntentSubmit}
               onEditAutomations={() => setShowIntentQuestions(true)}
               onDeleteItem={handleDeletePreuploaded}
+              onUpload={onRequestUpload}
             />
           );
         }

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 
-import { AlertTriangle, FileAudio, Loader2, RefreshCcw, Sparkles, Trash2 } from 'lucide-react';
+import { AlertTriangle, FileAudio, Loader2, RefreshCcw, Sparkles, Trash2, Upload } from 'lucide-react';
 
 const formatDate = (iso) => {
   if (!iso) return '—';
@@ -37,6 +37,7 @@ export default function StepSelectPreprocessed({
   onIntentSubmit,
   onEditAutomations,
   onDeleteItem = null,
+  onUpload,
 }) {
   const hasPendingIntents = Array.isArray(pendingIntentLabels) && pendingIntentLabels.length > 0;
 
@@ -68,8 +69,14 @@ export default function StepSelectPreprocessed({
 
   return (
     <div className="space-y-6">
-      <CardHeader className="text-center">
+      <CardHeader className="flex flex-col gap-3 text-center sm:text-left sm:flex-row sm:items-center sm:justify-between">
         <CardTitle style={{ color: '#2C3E50' }}>Step 2: Choose Your Processed Audio</CardTitle>
+        {typeof onUpload === 'function' && (
+          <Button variant="outline" size="sm" onClick={onUpload} className="self-center">
+            <Upload className="w-4 h-4 mr-2" />
+            Upload audio
+          </Button>
+        )}
       </CardHeader>
 
       <Card className="bg-slate-50 border border-slate-200">
@@ -98,8 +105,16 @@ export default function StepSelectPreprocessed({
               </div>
             )}
             {!loading && items.length === 0 && (
-              <div className="py-10 text-center text-sm text-slate-500">
-                No uploads yet. Upload audio from the previous step to see it here.
+              <div className="py-10 px-6 text-center text-sm text-slate-600 space-y-4">
+                <p className="text-base font-medium text-slate-700">No processed uploads yet</p>
+                <p>
+                  Upload audio so we can work our magic. Once it’s processed you’ll find it here, ready with transcripts and automations.
+                </p>
+                {typeof onUpload === 'function' && (
+                  <Button onClick={onUpload}>
+                    <Upload className="w-4 h-4 mr-2" /> Upload audio
+                  </Button>
+                )}
               </div>
             )}
             {!loading && items.length > 0 && (


### PR DESCRIPTION
## Summary
- simplify the episode start screen to focus on uploading new audio or jumping straight to processed uploads
- add an upload action and helpful empty-state guidance on the processed audio selection step
- automatically move creators into the processed audio step when choosing the preprocessed workflow

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8d852b4483208e845c77861d9fbb