### PR TITLE
Fix audio duration prop defaults in podcast creator steps

### DIFF
--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
@@ -38,8 +38,9 @@ export default function StepEpisodeDetails({
   minutesRequired = null,
   minutesRemaining = null,
   formatDuration = () => null,
-  audioDurationSec = null,
+  audioDurationSec: audioDurationSecProp = null,
 }) {
+  const audioDurationSec = audioDurationSecProp;
   const formatDurationSafe = typeof formatDuration === 'function' ? formatDuration : () => null;
   const parseNumber = (value) => {
     const num = Number(value);

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -46,8 +46,9 @@ export default function StepSelectPreprocessed({
   minutesRequired = null,
   minutesRemaining = null,
   formatDuration = () => null,
-  audioDurationSec = null,
+  audioDurationSec: audioDurationSecProp = null,
 }) {
+  const audioDurationSec = audioDurationSecProp;
   const hasPendingIntents = Array.isArray(pendingIntentLabels) && pendingIntentLabels.length > 0;
 
   const selected = useMemo(

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { FileAudio, Loader2, Mic, Upload, ArrowLeft, Lightbulb, AlertTriangle } from 'lucide-react';
+import { formatDisplayName } from '@/lib/displayNames';
 
 // Inline intent questions were removed in favor of the floating modal.
 
@@ -28,8 +29,9 @@ export default function StepUploadAudio({
   minutesRequired = null,
   minutesRemaining = null,
   formatDuration = () => null,
-  audioDurationSec = null,
+  audioDurationSec: audioDurationSecProp = null,
 }) {
+  const audioDurationSec = audioDurationSecProp;
   const handleFileInput = (event) => {
     if (event.target.files?.[0]) {
       onFileChange(event.target.files[0]);


### PR DESCRIPTION
## Summary
- alias the audio duration prop defaults in podcast creator steps to avoid referencing an undefined identifier at runtime
- import the missing formatDisplayName helper used by the upload step so file names render correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd95938bdc8320b30d0126bf1ce2c3