### PR TITLE
Fix audio duration prop in PodcastCreator

### DIFF
--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -129,6 +129,7 @@ export default function PodcastCreator({
     usage,
     minutesNearCap,
     minutesRemaining,
+    audioDurationSec,
     minutesPrecheck,
     minutesPrecheckPending,
     minutesPrecheckError,


### PR DESCRIPTION
## Summary
- include the audioDurationSec value from usePodcastCreator so steps receive the audio length prop

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd993191d0832083940211d045da27