### PR TITLE
Fix minutes precheck display for unlimited plans

### DIFF
--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepEpisodeDetails.jsx
@@ -43,6 +43,7 @@ export default function StepEpisodeDetails({
   const audioDurationSec = audioDurationSecProp;
   const formatDurationSafe = typeof formatDuration === 'function' ? formatDuration : () => null;
   const parseNumber = (value) => {
+    if (value === null || value === undefined || value === '') return null;
     const num = Number(value);
     return Number.isFinite(num) ? num : null;
   };
@@ -132,7 +133,7 @@ export default function StepEpisodeDetails({
                   <p>Uploaded audio length <strong>{audioDurationText}</strong>.</p>
                 )}
                 {requiredMinutesText && (
-                  <p>Requires <strong>{requiredMinutesText}</strong> of processing time.</p>
+                  <p>Requires approximately <strong>{requiredMinutesText}</strong> of processing time.</p>
                 )}
                 {remainingMinutesText && (
                   <p>Your plan has <strong>{remainingMinutesText}</strong> remaining.</p>

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -83,6 +83,7 @@ export default function StepSelectPreprocessed({
 
   const formatDurationSafe = typeof formatDuration === 'function' ? formatDuration : () => null;
   const parseNumber = (value) => {
+    if (value === null || value === undefined || value === '') return null;
     const num = Number(value);
     return Number.isFinite(num) ? num : null;
   };
@@ -284,7 +285,7 @@ export default function StepSelectPreprocessed({
                   <p>Uploaded audio length <strong>{audioDurationText}</strong>.</p>
                 )}
                 {requiredMinutesText && (
-                  <p>Requires <strong>{requiredMinutesText}</strong> of processing time.</p>
+                  <p>Requires approximately <strong>{requiredMinutesText}</strong> of processing time.</p>
                 )}
                 {remainingMinutesText && (
                   <p>Your plan has <strong>{remainingMinutesText}</strong> remaining.</p>

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepUploadAudio.jsx
@@ -63,6 +63,7 @@ export default function StepUploadAudio({
 
   const formatDurationSafe = typeof formatDuration === 'function' ? formatDuration : () => null;
   const parseNumber = (value) => {
+    if (value === null || value === undefined || value === '') return null;
     const num = Number(value);
     return Number.isFinite(num) ? num : null;
   };
@@ -268,7 +269,7 @@ export default function StepUploadAudio({
                   <p>Uploaded audio length <strong>{audioDurationText}</strong>.</p>
                 )}
                 {requiredMinutesText && (
-                  <p>Requires <strong>{requiredMinutesText}</strong> of processing time.</p>
+                  <p>Requires approximately <strong>{requiredMinutesText}</strong> of processing time.</p>
                 )}
                 {remainingMinutesText && (
                   <p>Your plan has <strong>{remainingMinutesText}</strong> remaining.</p>


### PR DESCRIPTION
## Summary
- prevent unlimited plans from showing 0 remaining minutes by ignoring null values when parsing numbers
- update processing minutes messaging to say "Requires approximately" for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9e32f57483208cf87466af9180f8