### PR TITLE
Allow overriding TTS API key for intern responses

### DIFF
--- a/backend/api/services/ai_enhancer.py
+++ b/backend/api/services/ai_enhancer.py
@@ -38,11 +38,12 @@ def generate_speech_from_text(
     google_voice: str | None = None,
     speaking_rate: float = 1.0,
     user: Optional[User] = None,
+    api_key: str | None = None,
 ) -> AudioSegment:
     """Generate speech from text using the requested provider."""
 
     if provider == "elevenlabs":
-        return _generate_with_elevenlabs(text, voice_id=voice_id, user=user)
+        return _generate_with_elevenlabs(text, voice_id=voice_id, user=user, api_key_override=api_key)
     if provider == "google":
         raise AIEnhancerError("Google TTS provider is not yet implemented.")
     raise AIEnhancerError(f"Unsupported TTS provider: {provider}")
@@ -53,8 +54,13 @@ def _generate_with_elevenlabs(
     *,
     voice_id: str | None,
     user: Optional[User],
+    api_key_override: str | None,
 ) -> AudioSegment:
-    api_key = (user and user.elevenlabs_api_key) or settings.ELEVENLABS_API_KEY
+    api_key = (
+        api_key_override
+        or (user and user.elevenlabs_api_key)
+        or settings.ELEVENLABS_API_KEY
+    )
     if not api_key or api_key == "dummy":
         raise AIEnhancerError("ElevenLabs API key is not configured on the server or for your user account.")
 


### PR DESCRIPTION
## Summary
- allow the AI enhancer's TTS helper to accept an optional API key override
- prefer the provided key when generating ElevenLabs audio so intern replies can synthesize speech

## Testing
- pytest backend/api/tests/services/test_ai_enhancer.py

------
https://chatgpt.com/codex/tasks/task_e_68dda25dc5c483208dd2eb69cf6169d0