### PR TITLE
Add missing upload option when selecting processed audio

### DIFF
--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -315,21 +315,22 @@ export default function PodcastCreator({
               onBack={() => setCurrentStep(1)}
               onNext={() => setCurrentStep(3)}
               onRefresh={onRefreshPreuploaded}
+              onUpload={onRequestUpload}
               intents={intents}
-            pendingIntentLabels={pendingIntentLabels}
-            onIntentSubmit={handleIntentSubmit}
-            onEditAutomations={() => setShowIntentQuestions(true)}
-            onDeleteItem={handleDeletePreuploaded}
-            minutesPrecheck={minutesPrecheck}
-            minutesPrecheckPending={minutesPrecheckPending}
-            minutesPrecheckError={minutesPrecheckError}
-            minutesBlocking={minutesBlocking}
-            minutesBlockingMessage={minutesBlockingMessage}
-            minutesRequired={minutesRequiredPrecheck}
-            minutesRemaining={minutesRemainingPrecheck}
-            formatDuration={formatDuration}
-            audioDurationSec={audioDurationSec}
-          />
+              pendingIntentLabels={pendingIntentLabels}
+              onIntentSubmit={handleIntentSubmit}
+              onEditAutomations={() => setShowIntentQuestions(true)}
+              onDeleteItem={handleDeletePreuploaded}
+              minutesPrecheck={minutesPrecheck}
+              minutesPrecheckPending={minutesPrecheckPending}
+              minutesPrecheckError={minutesPrecheckError}
+              minutesBlocking={minutesBlocking}
+              minutesBlockingMessage={minutesBlockingMessage}
+              minutesRequired={minutesRequiredPrecheck}
+              minutesRemaining={minutesRemainingPrecheck}
+              formatDuration={formatDuration}
+              audioDurationSec={audioDurationSec}
+            />
           );
         }
         return (

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepSelectPreprocessed.jsx
@@ -33,6 +33,7 @@ export default function StepSelectPreprocessed({
   onBack,
   onNext,
   onRefresh,
+  onUpload = null,
   intents = {},
   pendingIntentLabels = [],
   onIntentSubmit,


### PR DESCRIPTION
## Summary
- allow the processed audio selection step to request uploads by wiring through the upload handler
- show the Upload audio button when browsing processed files so users can jump to the uploader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda78a975c8320af6d44e3e5c39814