### PR TITLE
Fix episode assembly content lookup fallback

### DIFF
--- a/tests/test_orchestrator_steps.py
+++ b/tests/test_orchestrator_steps.py
@@ -15,6 +15,24 @@ def log():
     return []
 
 
+def test_load_content_prefers_ws_root(monkeypatch, log):
+    fname = 'cleaned_example.mp3'
+    ws_media = steps.WS_ROOT / 'media_uploads'
+    ws_media.mkdir(parents=True, exist_ok=True)
+    target = ws_media / fname
+    target.write_bytes(b'fake')
+
+    monkeypatch.setattr(steps.AudioSegment, 'from_file', lambda path: FakeAudio())
+    monkeypatch.setattr(steps.transcription, 'get_word_timestamps', lambda *_: [])
+
+    content_path, audio, words, sanitized = steps.load_content_and_init_transcripts(fname, None, 'Episode Name', log)
+
+    assert content_path == target
+    assert isinstance(audio, FakeAudio)
+    assert words == []
+    assert sanitized == 'episode-name'
+
+
 def test_do_transcript_io_shape(monkeypatch, log):
     def fake_load(fname, words_json, out_name, log_):
         # No logs needed here; focus on shape


### PR DESCRIPTION
## Summary
- expand the content lookup helper to consider workspace media directories, cleaned audio roots, and absolute paths so assembly can load uploaded mixes
- import the shared WS_ROOT constant and deduplicate candidate paths to avoid spurious misses when resolving audio
- add a regression test that ensures load_content_and_init_transcripts finds files staged under ws_root/media_uploads

## Testing
- pytest tests/test_orchestrator_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb6bc774883209d7cd2ed3f72a807