### PR TITLE
Ensure processed upload timestamps respect user timezone

### DIFF
--- a/frontend/src/components/dashboard.jsx
+++ b/frontend/src/components/dashboard.jsx
@@ -493,6 +493,7 @@ export default function PodcastPlusDashboard() {
               setCreatorMode('standard');
               setCurrentView('preuploadUpload');
             }}
+            userTimezone={user?.timezone || authUser?.timezone || null}
           />
         );
       case 'mediaLibrary':

--- a/frontend/src/components/dashboard/PodcastCreator.jsx
+++ b/frontend/src/components/dashboard/PodcastCreator.jsx
@@ -35,6 +35,7 @@ export default function PodcastCreator({
   onRefreshPreuploaded = () => {},
   preselectedStartStep,
   onRequestUpload,
+  userTimezone = null,
 }) {
   const controller = usePodcastCreator({
     token,
@@ -330,6 +331,7 @@ export default function PodcastCreator({
               minutesRemaining={minutesRemainingPrecheck}
               formatDuration={formatDuration}
               audioDurationSec={audioDurationSec}
+              userTimezone={userTimezone}
             />
           );
         }


### PR DESCRIPTION
## Summary
- plumb the user profile timezone into the podcast creator flow
- render processed upload timestamps with Intl using the resolved timezone instead of implicit UTC fallback

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68ddb83ac7748320a35f363251356f34