### PR TITLE
Restore GCS download helper alias

### DIFF
--- a/backend/infrastructure/gcs.py
+++ b/backend/infrastructure/gcs.py
@@ -455,6 +455,26 @@ def download_gcs_bytes(bucket_name: str, key: str) -> Optional[bytes]:
     return local_path.read_bytes()
 
 
+def download_bytes(bucket_name: str, key: str) -> Optional[bytes]:
+    """Backwards compatible wrapper for legacy imports.
+
+    Several parts of the codebase still import :func:`download_bytes` from this
+    module.  During the infrastructure/worker split the helper was renamed to
+    :func:`download_gcs_bytes`, but the old symbol was never re-exported.  The
+    resulting ``ImportError`` caused transcript downloads to silently fail in
+    worker processes (they fall back to ``None`` when the import is missing),
+    which meant assembly could not locate existing transcript JSON artefacts
+    stored in GCS.  Episode assembly would then skip cleanup because
+    ``words_json_path`` was ``None``.
+
+    Providing a thin wrapper keeps existing call sites working and restores the
+    expected behaviour without changing their imports.  New code should prefer
+    :func:`download_gcs_bytes` but both names now behave identically.
+    """
+
+    return download_gcs_bytes(bucket_name, key)
+
+
 def delete_gcs_blob(bucket_name: str, blob_name: str) -> None:
     """Delete a blob from a GCS bucket, ignoring failures in development."""
 

--- a/tests/test_orchestrator_steps.py
+++ b/tests/test_orchestrator_steps.py
@@ -54,7 +54,7 @@ def test_load_content_scans_for_alternates(monkeypatch, log):
     assert sanitized == 'episode-name-2'
 
 def test_do_transcript_io_shape(monkeypatch, log):
-    def fake_load(fname, words_json, out_name, log_):
+    def fake_load(fname, words_json, out_name, log_, **kwargs):
         # No logs needed here; focus on shape
         return Path('media/foo.mp3'), FakeAudio(), [{'word': 'hello', 'start': 0.0, 'end': 0.1}], 'episode_sanitized'
 


### PR DESCRIPTION
## Summary
- add a backwards-compatible `download_bytes` wrapper in `backend/infrastructure/gcs.py` so workers can fetch transcript JSON from GCS again
- update the orchestrator unit test stub to accept keyword arguments to match the production helper signature

## Testing
- pytest tests/test_orchestrator_steps.py -q --disable-warnings --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68de071183ec8320abe3d99d8323ce2f