### PR TITLE
Fix worker tasks initialization without python-dotenv

### DIFF
--- a/backend/worker/tasks/__init__.py
+++ b/backend/worker/tasks/__init__.py
@@ -60,10 +60,22 @@ def _load_legacy_shim() -> None:
         pass
 
 
-if not (
-    transcribe_media_file and create_podcast_episode and publish_episode_to_spreaker_task
-):
+_required_exports = (
+    "transcribe_media_file",
+    "create_podcast_episode",
+    "publish_episode_to_spreaker_task",
+)
+
+if not all(globals().get(name) for name in _required_exports):
     _load_legacy_shim()
+
+missing = [name for name in _required_exports if globals().get(name) is None]
+if missing:
+    raise ImportError(
+        "worker.tasks failed to import required callables: {}".format(
+            ", ".join(sorted(missing))
+        )
+    )
 
 
 __all__ = [

--- a/backend/worker/tasks/app.py
+++ b/backend/worker/tasks/app.py
@@ -3,7 +3,15 @@ import logging
 from pathlib import Path
 
 from celery import Celery
-from dotenv import load_dotenv
+
+try:  # pragma: no cover - exercised via import in tests
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        logging.getLogger(__name__).warning(
+            "[celery] python-dotenv not installed; skipping load_dotenv() call.",
+        )
+        return False
 from celery.schedules import crontab
 
 # Load env first

--- a/tests/worker/test_tasks_import.py
+++ b/tests/worker/test_tasks_import.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import types
+
+
+def _install_stub(monkeypatch, name: str, attr: str):
+    module = types.ModuleType(name)
+
+    def _callable(*args, **kwargs):
+        return {"name": name, "args": args, "kwargs": kwargs}
+
+    setattr(module, attr, _callable)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_import_worker_tasks_without_dotenv(monkeypatch):
+    monkeypatch.setitem(sys.modules, "dotenv", None)
+
+    for name in list(sys.modules):
+        if name.startswith(("backend.worker.tasks", "worker.tasks")):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    transcription_stub = _install_stub(
+        monkeypatch, "backend.worker.tasks.transcription", "transcribe_media_file"
+    )
+    assembly_stub = _install_stub(
+        monkeypatch, "backend.worker.tasks.assembly", "create_podcast_episode"
+    )
+    publish_stub = _install_stub(
+        monkeypatch,
+        "backend.worker.tasks.publish",
+        "publish_episode_to_spreaker_task",
+    )
+
+    monkeypatch.setitem(
+        sys.modules, "worker.tasks.transcription", transcription_stub
+    )
+    monkeypatch.setitem(sys.modules, "worker.tasks.assembly", assembly_stub)
+    monkeypatch.setitem(sys.modules, "worker.tasks.publish", publish_stub)
+
+    tasks_module = importlib.import_module("backend.worker.tasks")
+
+    assert callable(tasks_module.create_podcast_episode)
+    assert callable(tasks_module.transcribe_media_file)
+    assert callable(tasks_module.publish_episode_to_spreaker_task)


### PR DESCRIPTION
## Summary
- wrap the optional python-dotenv import in the Celery bootstrap with a no-op shim and warning when the dependency is absent
- raise a descriptive ImportError if worker.tasks cannot expose its expected task callables even after the legacy shim runs
- add a regression test that stubs task modules and verifies worker.tasks still exports callables when python-dotenv is unavailable

## Testing
- pytest tests/worker/test_tasks_import.py


------
https://chatgpt.com/codex/tasks/task_e_68de1fa647ec832093895393e44e76b0