### PR TITLE
Add feedback tracking system with comments and voting

### DIFF
--- a/backend/api/core/database.py
+++ b/backend/api/core/database.py
@@ -12,6 +12,7 @@ from ..models import recurring as _recurring_models  # noqa: F401
 from ..models import usage as _usage_models  # noqa: F401
 from ..models import website as _website_models  # noqa: F401
 from ..models import transcription as _transcription_models  # noqa: F401
+from ..models import feedback as _feedback_models  # noqa: F401
 from pathlib import Path
 from .config import settings
 

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -11,3 +11,16 @@ from .usage import ProcessingMinutesLedger, LedgerDirection, LedgerReason  # noq
 from .recurring import RecurringSchedule  # noqa: F401
 from .website import PodcastWebsite, PodcastWebsiteStatus  # noqa: F401
 from .transcription import TranscriptionWatch  # noqa: F401
+from .feedback import (  # noqa: F401
+    Feedback,
+    FeedbackComment,
+    FeedbackCommentPublic,
+    FeedbackCreate,
+    FeedbackDetail,
+    FeedbackPublic,
+    FeedbackStatus,
+    FeedbackType,
+    FeedbackUpdate,
+    FeedbackVote,
+    FeedbackVoteRequest,
+)

--- a/backend/api/models/feedback.py
+++ b/backend/api/models/feedback.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+from pydantic import field_validator
+from sqlalchemy import Column, Text, UniqueConstraint
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class FeedbackType(str, Enum):
+    BUG = "bug"
+    FEATURE = "feature"
+    OTHER = "other"
+
+
+class FeedbackStatus(str, Enum):
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    CLOSED = "closed"
+
+
+class FeedbackBase(SQLModel):
+    title: str = Field(max_length=200, description="Short summary for the feedback item")
+    body: str = Field(sa_column=Column(Text, nullable=False), description="Detailed description of the feedback")
+    type: FeedbackType = Field(default=FeedbackType.BUG, description="Classification of the feedback item")
+
+    @field_validator("title")
+    @classmethod
+    def _validate_title(cls, value: str) -> str:
+        text = (value or "").strip()
+        if len(text) < 3:
+            raise ValueError("Title must be at least 3 characters long")
+        return text
+
+    @field_validator("body")
+    @classmethod
+    def _validate_body(cls, value: str) -> str:
+        text = (value or "").strip()
+        if len(text) < 10:
+            raise ValueError("Please provide a little more detail so we can take action")
+        return text
+
+
+class Feedback(FeedbackBase, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    user_id: UUID = Field(foreign_key="user.id", index=True, description="Author of the feedback")
+    status: FeedbackStatus = Field(default=FeedbackStatus.OPEN, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    comments: List["FeedbackComment"] = Relationship(back_populates="feedback")
+    votes: List["FeedbackVote"] = Relationship(back_populates="feedback")
+
+
+class FeedbackPublic(FeedbackBase):
+    id: UUID
+    user_id: UUID
+    status: FeedbackStatus
+    created_at: datetime
+    updated_at: datetime
+    creator_name: Optional[str] = None
+    creator_email: Optional[str] = None
+    comment_count: int = 0
+    upvotes: int = 0
+    downvotes: int = 0
+    user_vote: Optional[int] = None
+
+
+class FeedbackCreate(FeedbackBase):
+    pass
+
+
+class FeedbackUpdate(SQLModel):
+    status: FeedbackStatus
+
+
+class FeedbackCommentBase(SQLModel):
+    body: str = Field(sa_column=Column(Text, nullable=False))
+
+    @field_validator("body")
+    @classmethod
+    def _validate_body(cls, value: str) -> str:
+        text = (value or "").strip()
+        if len(text) < 2:
+            raise ValueError("Comment is too short")
+        return text
+
+
+class FeedbackComment(FeedbackCommentBase, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    feedback_id: UUID = Field(foreign_key="feedback.id", index=True)
+    user_id: UUID = Field(foreign_key="user.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    feedback: Optional[Feedback] = Relationship(back_populates="comments")
+
+
+class FeedbackCommentCreate(FeedbackCommentBase):
+    pass
+
+
+class FeedbackCommentPublic(FeedbackCommentBase):
+    id: UUID
+    feedback_id: UUID
+    user_id: UUID
+    created_at: datetime
+    author_name: Optional[str] = None
+    author_email: Optional[str] = None
+
+
+class FeedbackVote(SQLModel, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    feedback_id: UUID = Field(foreign_key="feedback.id", index=True)
+    user_id: UUID = Field(foreign_key="user.id", index=True)
+    value: int = Field(default=0, description="-1 for thumbs down, 1 for thumbs up")
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    feedback: Optional[Feedback] = Relationship(back_populates="votes")
+
+    __table_args__ = (
+        UniqueConstraint("feedback_id", "user_id", name="uq_feedback_vote_user"),
+    )
+
+
+class FeedbackVoteRequest(SQLModel):
+    value: int
+
+    @field_validator("value")
+    @classmethod
+    def _validate_value(cls, value: int) -> int:
+        if value not in (-1, 0, 1):
+            raise ValueError("Vote must be -1, 0, or 1")
+        return value
+
+
+class FeedbackDetail(FeedbackPublic):
+    comments: List[FeedbackCommentPublic] = Field(default_factory=list)

--- a/backend/api/routers/feedback.py
+++ b/backend/api/routers/feedback.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import case, func
+from sqlmodel import Session, select
+
+from api.core.config import settings
+from api.core.database import get_session
+from api.models.feedback import (
+    Feedback,
+    FeedbackComment,
+    FeedbackCommentCreate,
+    FeedbackCommentPublic,
+    FeedbackCreate,
+    FeedbackDetail,
+    FeedbackPublic,
+    FeedbackStatus,
+    FeedbackType,
+    FeedbackUpdate,
+    FeedbackVote,
+    FeedbackVoteRequest,
+)
+from api.models.user import User
+from api.routers.auth import get_current_user
+
+router = APIRouter(prefix="/feedback", tags=["feedback"])
+
+
+def _is_admin_user(user: User) -> bool:
+    try:
+        admin_email = getattr(settings, "ADMIN_EMAIL", None)
+        email = getattr(user, "email", None)
+        if admin_email and email and email.lower() == str(admin_email).lower():
+            return True
+    except Exception:
+        pass
+    if getattr(user, "is_admin", False):
+        return True
+    try:
+        role = str(getattr(user, "role", ""))
+        if role.lower() == "admin":
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _display_name(user: User) -> Optional[str]:
+    parts = []
+    first = getattr(user, "first_name", None)
+    if first:
+        parts.append(str(first).strip())
+    last = getattr(user, "last_name", None)
+    if last:
+        parts.append(str(last).strip())
+    name = " ".join(p for p in parts if p)
+    if name:
+        return name
+    if first:
+        first_clean = str(first).strip()
+        if first_clean:
+            return first_clean
+    email = getattr(user, "email", None)
+    if email:
+        try:
+            return str(email).split("@", 1)[0]
+        except Exception:
+            return str(email)
+    return None
+
+
+def _load_authors(session: Session, user_ids: Iterable[UUID]) -> Dict[UUID, Dict[str, Optional[str]]]:
+    ids = {uid for uid in user_ids if uid is not None}
+    if not ids:
+        return {}
+    rows = session.exec(select(User).where(User.id.in_(ids))).all()
+    return {
+        row.id: {
+            "name": _display_name(row),
+            "email": getattr(row, "email", None),
+        }
+        for row in rows
+    }
+
+
+def _aggregate_counts(session: Session, feedback_ids: List[UUID], current_user: User):
+    comment_counts: Dict[UUID, int] = defaultdict(int)
+    vote_counts: Dict[UUID, Dict[str, int]] = defaultdict(lambda: {"up": 0, "down": 0})
+    user_votes: Dict[UUID, Optional[int]] = {}
+
+    if not feedback_ids:
+        return comment_counts, vote_counts, user_votes
+
+    comment_stmt = (
+        select(FeedbackComment.feedback_id, func.count(FeedbackComment.id))
+        .where(FeedbackComment.feedback_id.in_(feedback_ids))
+        .group_by(FeedbackComment.feedback_id)
+    )
+    for row in session.exec(comment_stmt):
+        fid = row[0]
+        count = row[1]
+        comment_counts[fid] = int(count or 0)
+
+    vote_stmt = (
+        select(
+            FeedbackVote.feedback_id,
+            func.sum(case((FeedbackVote.value > 0, 1), else_=0)).label("upvotes"),
+            func.sum(case((FeedbackVote.value < 0, 1), else_=0)).label("downvotes"),
+        )
+        .where(FeedbackVote.feedback_id.in_(feedback_ids))
+        .group_by(FeedbackVote.feedback_id)
+    )
+    for row in session.exec(vote_stmt):
+        fid = row[0]
+        up = int(row.upvotes or 0)
+        down = int(row.downvotes or 0)
+        vote_counts[fid] = {"up": up, "down": down}
+
+    user_vote_stmt = select(FeedbackVote.feedback_id, FeedbackVote.value).where(
+        FeedbackVote.feedback_id.in_(feedback_ids),
+        FeedbackVote.user_id == current_user.id,
+    )
+    for row in session.exec(user_vote_stmt):
+        fid = row[0]
+        val = row[1]
+        user_votes[fid] = int(val) if val is not None else None
+
+    return comment_counts, vote_counts, user_votes
+
+
+def _to_public(
+    feedback: Feedback,
+    authors: Dict[UUID, Dict[str, Optional[str]]],
+    comment_counts: Dict[UUID, int],
+    vote_counts: Dict[UUID, Dict[str, int]],
+    user_votes: Dict[UUID, Optional[int]],
+) -> FeedbackPublic:
+    author = authors.get(feedback.user_id, {})
+    votes = vote_counts.get(feedback.id, {"up": 0, "down": 0})
+    return FeedbackPublic(
+        id=feedback.id,
+        title=feedback.title,
+        body=feedback.body,
+        type=feedback.type,
+        status=feedback.status,
+        created_at=feedback.created_at,
+        updated_at=feedback.updated_at,
+        user_id=feedback.user_id,
+        creator_name=author.get("name"),
+        creator_email=author.get("email"),
+        comment_count=comment_counts.get(feedback.id, 0),
+        upvotes=votes.get("up", 0),
+        downvotes=votes.get("down", 0),
+        user_vote=user_votes.get(feedback.id),
+    )
+
+
+def _to_detail(session: Session, feedback: Feedback, current_user: User) -> FeedbackDetail:
+    comment_counts, vote_counts, user_votes = _aggregate_counts(session, [feedback.id], current_user)
+    comments = session.exec(
+        select(FeedbackComment)
+        .where(FeedbackComment.feedback_id == feedback.id)
+        .order_by(FeedbackComment.created_at.asc())
+    ).all()
+
+    author_ids = {feedback.user_id, *(comment.user_id for comment in comments)}
+    authors = _load_authors(session, author_ids)
+    public = _to_public(feedback, authors, comment_counts, vote_counts, user_votes)
+
+    comment_payload = [
+        FeedbackCommentPublic(
+            id=comment.id,
+            feedback_id=comment.feedback_id,
+            user_id=comment.user_id,
+            body=comment.body,
+            created_at=comment.created_at,
+            author_name=authors.get(comment.user_id, {}).get("name"),
+            author_email=authors.get(comment.user_id, {}).get("email"),
+        )
+        for comment in comments
+    ]
+
+    data = public.model_dump()
+    data["comments"] = comment_payload
+    return FeedbackDetail(**data)
+
+
+def _list_public(session: Session, items: List[Feedback], current_user: User) -> List[FeedbackPublic]:
+    if not items:
+        return []
+    feedback_ids = [item.id for item in items]
+    author_ids = {item.user_id for item in items}
+    authors = _load_authors(session, author_ids)
+    comment_counts, vote_counts, user_votes = _aggregate_counts(session, feedback_ids, current_user)
+    return [_to_public(item, authors, comment_counts, vote_counts, user_votes) for item in items]
+
+
+@router.get("/", response_model=List[FeedbackPublic])
+def list_feedback(
+    feedback_type: Optional[FeedbackType] = Query(None, alias="type"),
+    status: Optional[FeedbackStatus] = None,
+    limit: int = Query(200, ge=1, le=200),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> List[FeedbackPublic]:
+    stmt = select(Feedback).order_by(Feedback.created_at.desc()).limit(limit)
+    if feedback_type is not None:
+        stmt = stmt.where(Feedback.type == feedback_type)
+    if status is not None:
+        stmt = stmt.where(Feedback.status == status)
+    items = session.exec(stmt).all()
+    return _list_public(session, items, current_user)
+
+
+@router.get("/{feedback_id}", response_model=FeedbackDetail)
+def get_feedback(
+    feedback_id: UUID,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> FeedbackDetail:
+    feedback = session.get(Feedback, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    return _to_detail(session, feedback, current_user)
+
+
+@router.post("/", response_model=FeedbackDetail)
+def create_feedback(
+    payload: FeedbackCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> FeedbackDetail:
+    feedback = Feedback(
+        title=payload.title,
+        body=payload.body,
+        type=payload.type,
+        user_id=current_user.id,
+    )
+    session.add(feedback)
+    session.commit()
+    session.refresh(feedback)
+    return _to_detail(session, feedback, current_user)
+
+
+@router.patch("/{feedback_id}", response_model=FeedbackDetail)
+def update_feedback(
+    feedback_id: UUID,
+    payload: FeedbackUpdate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> FeedbackDetail:
+    feedback = session.get(Feedback, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    if feedback.user_id != current_user.id and not _is_admin_user(current_user):
+        raise HTTPException(status_code=403, detail="You do not have permission to update this item")
+
+    if feedback.status != payload.status:
+        feedback.status = payload.status
+        feedback.updated_at = datetime.utcnow()
+        session.add(feedback)
+        session.commit()
+        session.refresh(feedback)
+    else:
+        session.refresh(feedback)
+    return _to_detail(session, feedback, current_user)
+
+
+@router.post("/{feedback_id}/comments", response_model=FeedbackDetail)
+def add_comment(
+    feedback_id: UUID,
+    payload: FeedbackCommentCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> FeedbackDetail:
+    feedback = session.get(Feedback, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+
+    comment = FeedbackComment(
+        feedback_id=feedback.id,
+        user_id=current_user.id,
+        body=payload.body,
+    )
+    session.add(comment)
+    feedback.updated_at = datetime.utcnow()
+    session.add(feedback)
+    session.commit()
+    session.refresh(feedback)
+    return _to_detail(session, feedback, current_user)
+
+
+@router.post("/{feedback_id}/vote", response_model=FeedbackDetail)
+def vote_on_feedback(
+    feedback_id: UUID,
+    payload: FeedbackVoteRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> FeedbackDetail:
+    feedback = session.get(Feedback, feedback_id)
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    if feedback.type != FeedbackType.FEATURE:
+        raise HTTPException(status_code=400, detail="Voting is only available on feature requests")
+
+    desired_value = 0 if payload.value == 0 else (1 if payload.value > 0 else -1)
+
+    existing = session.exec(
+        select(FeedbackVote).where(
+            FeedbackVote.feedback_id == feedback.id,
+            FeedbackVote.user_id == current_user.id,
+        )
+    ).first()
+
+    if desired_value == 0:
+        if existing is not None:
+            session.delete(existing)
+    else:
+        if existing is not None:
+            existing.value = desired_value
+            session.add(existing)
+        else:
+            session.add(FeedbackVote(feedback_id=feedback.id, user_id=current_user.id, value=desired_value))
+
+    feedback.updated_at = datetime.utcnow()
+    session.add(feedback)
+    session.commit()
+    session.refresh(feedback)
+    return _to_detail(session, feedback, current_user)

--- a/backend/api/routing.py
+++ b/backend/api/routing.py
@@ -92,6 +92,7 @@ transcripts_router     = _safe_import("api.routers.transcripts")
 elevenlabs_router      = _safe_import("api.routers.elevenlabs")
 media_tts_router       = _safe_import("api.routers.media_tts")
 dashboard_router       = _safe_import("api.routers.dashboard")
+feedback_router        = _safe_import("api.routers.feedback")
 recurring              = _safe_import("api.routers.recurring")
 assemblyai_router      = _safe_import("api.routers.assemblyai_webhook")
 media_upload_alias     = _safe_import("api.routers.media_upload_alias")
@@ -166,6 +167,8 @@ def attach_routers(app: FastAPI) -> dict:
     availability['media_tts_router'] = media_tts_router is not None
     _maybe(app, dashboard_router)
     availability['dashboard_router'] = dashboard_router is not None
+    _maybe(app, feedback_router)
+    availability['feedback_router'] = feedback_router is not None
     _maybe(app, recurring)
     availability['recurring'] = recurring is not None
     _maybe(app, assemblyai_router)

--- a/frontend/src/components/dashboard.jsx
+++ b/frontend/src/components/dashboard.jsx
@@ -29,6 +29,7 @@ import {
   Settings as SettingsIcon,
   DollarSign,
   Globe2,
+  MessageSquare,
 } from "lucide-react";
 import { useState, useEffect, useMemo, useCallback } from "react";
 
@@ -55,6 +56,7 @@ import TemplateManager from "@/components/dashboard/TemplateManager";
 import BillingPage from "@/components/dashboard/BillingPage";
 import Recorder from "@/components/quicktools/Recorder";
 import WebsiteBuilder from "@/components/dashboard/WebsiteBuilder.jsx";
+import FeedbackCenter from "@/components/dashboard/FeedbackCenter.jsx";
 
 const isAdmin = (u) => !!(u && (u.is_admin || u.role === 'admin'));
 const DASHBOARD_TOUR_STORAGE_KEY = 'ppp_dashboard_tour_completed';
@@ -528,6 +530,15 @@ export default function PodcastPlusDashboard() {
           : <div className="p-6 text-sm text-red-600">Not authorized.</div>;
       case 'settings':
         return <Settings token={token} />;
+      case 'feedbackCenter':
+        return (
+          <FeedbackCenter
+            token={token}
+            onBack={handleBackToDashboard}
+            currentUser={user}
+            canModerate={isAdmin(authUser)}
+          />
+        );
       case 'templateWizard':
         return <TemplateWizard user={user} token={token} onBack={() => setCurrentView('templateManager')} onTemplateCreated={() => { fetchData(); setCurrentView('templateManager'); }} />;
       case 'billing':
@@ -685,6 +696,7 @@ export default function PodcastPlusDashboard() {
           {/* Import moved under Podcasts */}
           <Button onClick={() => setCurrentView('billing')} variant="outline" className="justify-start text-sm h-10" data-tour-id="dashboard-quicktool-subscription"><DollarSign className="w-4 h-4 mr-2" />Subscription</Button>
                       <Button onClick={() => setCurrentView('settings')} variant="outline" className="justify-start text-sm h-10" data-tour-id="dashboard-quicktool-settings"><SettingsIcon className="w-4 h-4 mr-2" />Settings</Button>
+                      <Button onClick={() => setCurrentView('feedbackCenter')} variant="outline" className="justify-start text-sm h-10"><MessageSquare className="w-4 h-4 mr-2" />Feedback</Button>
                       <Button
                         onClick={() => setCurrentView('websiteBuilder')}
                         variant="outline"

--- a/frontend/src/components/dashboard/FeedbackCenter.jsx
+++ b/frontend/src/components/dashboard/FeedbackCenter.jsx
@@ -1,0 +1,602 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowLeft,
+  Loader2,
+  MessageCircle,
+  MessageSquarePlus,
+  ThumbsDown,
+  ThumbsUp,
+} from "lucide-react";
+
+import { makeApi, coerceArray } from "@/lib/apiClient";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const TYPE_LABELS = {
+  feature: "Feature Request",
+  bug: "Bug Report",
+  other: "Other",
+};
+
+const STATUS_LABELS = {
+  open: "Open",
+  in_progress: "In Progress",
+  closed: "Closed",
+};
+
+const STATUS_BADGES = {
+  open: "bg-blue-100 text-blue-800",
+  in_progress: "bg-amber-100 text-amber-800",
+  closed: "bg-emerald-100 text-emerald-800",
+};
+
+const STATUS_OPTIONS = [
+  { value: "open", label: "Mark Open" },
+  { value: "in_progress", label: "Mark In Progress" },
+  { value: "closed", label: "Mark Closed" },
+];
+
+const TYPE_TABS = [
+  { value: "all", label: "All" },
+  { value: "feature", label: "Features" },
+  { value: "bug", label: "Bugs" },
+  { value: "other", label: "Other" },
+];
+
+function formatRelativeTime(iso) {
+  if (!iso) return "";
+  try {
+    const value = new Date(iso);
+    const diffMs = Date.now() - value.getTime();
+    const diffSec = Math.floor(diffMs / 1000);
+    if (diffSec < 60) return "just now";
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDay = Math.floor(diffHr / 24);
+    if (diffDay < 30) return `${diffDay}d ago`;
+    const diffMonth = Math.floor(diffDay / 30);
+    if (diffMonth < 12) return `${diffMonth}mo ago`;
+    const diffYear = Math.floor(diffMonth / 12);
+    return `${diffYear}y ago`;
+  } catch {
+    return "";
+  }
+}
+
+function formatFullDate(iso) {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function FeedbackCenter({ token, onBack, currentUser, canModerate }) {
+  const { toast } = useToast();
+  const [items, setItems] = useState([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedType, setSelectedType] = useState("all");
+  const [selectedId, setSelectedId] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState(null);
+  const [newItem, setNewItem] = useState({ type: "feature", title: "", body: "" });
+  const [formError, setFormError] = useState(null);
+  const [creating, setCreating] = useState(false);
+  const [commentText, setCommentText] = useState("");
+  const [commentError, setCommentError] = useState(null);
+  const [commentSubmitting, setCommentSubmitting] = useState(false);
+  const [statusUpdating, setStatusUpdating] = useState(false);
+  const [voteBusy, setVoteBusy] = useState(false);
+
+  const applyDetailToList = useCallback((item) => {
+    if (!item) return;
+    setItems((prev) => {
+      const filtered = Array.isArray(prev) ? prev.filter((existing) => existing.id !== item.id) : [];
+      const merged = [item, ...filtered];
+      merged.sort((a, b) => {
+        const aTime = new Date(a.created_at || 0).getTime();
+        const bTime = new Date(b.created_at || 0).getTime();
+        return bTime - aTime;
+      });
+      return merged;
+    });
+  }, []);
+
+  const loadList = useCallback(
+    async (opts = { silent: false }) => {
+      if (!token) return [];
+      const api = makeApi(token);
+      if (opts.silent) {
+        setRefreshing(true);
+      } else {
+        setListLoading(true);
+        setListError(null);
+      }
+      try {
+        const data = await api.get("/api/feedback/");
+        const list = coerceArray(data);
+        setItems(list);
+        setListError(null);
+        return list;
+      } catch (err) {
+        const message = err?.detail || err?.message || "Unable to load feedback right now.";
+        setListError(message);
+        if (!opts.silent) {
+          setItems([]);
+        }
+        return [];
+      } finally {
+        if (opts.silent) {
+          setRefreshing(false);
+        } else {
+          setListLoading(false);
+        }
+      }
+    },
+    [token]
+  );
+
+  const loadDetail = useCallback(
+    async (id) => {
+      if (!token || !id) return null;
+      const api = makeApi(token);
+      setDetailLoading(true);
+      setDetailError(null);
+      try {
+        const data = await api.get(`/api/feedback/${id}`);
+        setDetail(data);
+        setDetailError(null);
+        return data;
+      } catch (err) {
+        const message = err?.detail || err?.message || "Unable to load that feedback item.";
+        setDetail(null);
+        setDetailError(message);
+        return null;
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [token]
+  );
+
+  useEffect(() => {
+    loadList();
+  }, [loadList]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      setDetailError(null);
+      return;
+    }
+    loadDetail(selectedId);
+  }, [selectedId, loadDetail]);
+
+  const filteredItems = useMemo(() => {
+    if (selectedType === "all") return items;
+    return items.filter((item) => item.type === selectedType);
+  }, [items, selectedType]);
+
+  useEffect(() => {
+    if (filteredItems.length === 0) {
+      return;
+    }
+    if (!selectedId || !filteredItems.some((item) => item.id === selectedId)) {
+      setSelectedId(filteredItems[0].id);
+    }
+  }, [filteredItems, selectedId]);
+
+  const handleCreate = async (event) => {
+    event.preventDefault();
+    if (!token) return;
+    const title = (newItem.title || "").trim();
+    const body = (newItem.body || "").trim();
+    if (title.length < 3 || body.length < 10) {
+      setFormError("Please provide a short title and a bit more detail.");
+      return;
+    }
+    setFormError(null);
+    setCreating(true);
+    try {
+      const api = makeApi(token);
+      const payload = { type: newItem.type, title, body };
+      const created = await api.post("/api/feedback/", payload);
+      applyDetailToList(created);
+      setDetail(created);
+      setSelectedType(created.type || newItem.type);
+      setSelectedId(created.id);
+      setNewItem((prev) => ({ ...prev, title: "", body: "" }));
+      toast({ title: "Feedback submitted", description: "Thanks for letting us know!" });
+    } catch (err) {
+      const message = err?.detail || err?.message || "Unable to submit feedback right now.";
+      setFormError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const canUpdateStatus = detail && (canModerate || detail.user_id === currentUser?.id);
+
+  const handleStatusChange = async (status) => {
+    if (!detail || !token) return;
+    if (detail.status === status) return;
+    setStatusUpdating(true);
+    try {
+      const api = makeApi(token);
+      const updated = await api.patch(`/api/feedback/${detail.id}`, { status });
+      applyDetailToList(updated);
+      setDetail(updated);
+      toast({ title: "Status updated", description: `Marked as ${STATUS_LABELS[status] || status}.` });
+    } catch (err) {
+      const message = err?.detail || err?.message || "Unable to update the status.";
+      toast({ title: "Update failed", description: message, variant: "destructive" });
+    } finally {
+      setStatusUpdating(false);
+    }
+  };
+
+  const handleAddComment = async (event) => {
+    event.preventDefault();
+    if (!detail || !token) return;
+    const trimmed = (commentText || "").trim();
+    if (trimmed.length < 2) {
+      setCommentError("Add a bit more detail to your comment.");
+      return;
+    }
+    setCommentError(null);
+    setCommentSubmitting(true);
+    try {
+      const api = makeApi(token);
+      const updated = await api.post(`/api/feedback/${detail.id}/comments`, { body: trimmed });
+      applyDetailToList(updated);
+      setDetail(updated);
+      setCommentText("");
+      toast({ title: "Comment posted" });
+    } catch (err) {
+      const message = err?.detail || err?.message || "Unable to add your comment.";
+      setCommentError(message);
+    } finally {
+      setCommentSubmitting(false);
+    }
+  };
+
+  const handleVote = async (value) => {
+    if (!detail || !token) return;
+    if (detail.type !== "feature") return;
+    const desired = detail.user_vote === value ? 0 : value;
+    setVoteBusy(true);
+    try {
+      const api = makeApi(token);
+      const updated = await api.post(`/api/feedback/${detail.id}/vote`, { value: desired });
+      applyDetailToList(updated);
+      setDetail(updated);
+    } catch (err) {
+      const message = err?.detail || err?.message || "Unable to record your vote.";
+      toast({ title: "Vote failed", description: message, variant: "destructive" });
+    } finally {
+      setVoteBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Button
+        variant="ghost"
+        className="px-0 w-auto text-slate-600 hover:text-slate-800"
+        onClick={onBack}
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to dashboard
+      </Button>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-1">
+          <Card className="border border-slate-200 shadow-sm">
+            <CardHeader>
+              <CardTitle>Share feedback</CardTitle>
+              <CardDescription>Report issues or suggest features we should build next.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-4" onSubmit={handleCreate}>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-slate-600" htmlFor="feedback-type">Type</label>
+                  <Select
+                    value={newItem.type}
+                    onValueChange={(value) => setNewItem((prev) => ({ ...prev, type: value }))}
+                  >
+                    <SelectTrigger id="feedback-type">
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="feature">Feature Request</SelectItem>
+                      <SelectItem value="bug">Bug Report</SelectItem>
+                      <SelectItem value="other">General Feedback</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-slate-600" htmlFor="feedback-title">Title</label>
+                  <Input
+                    id="feedback-title"
+                    placeholder="Give it a quick headline"
+                    value={newItem.title}
+                    onChange={(event) => setNewItem((prev) => ({ ...prev, title: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-slate-600" htmlFor="feedback-body">Details</label>
+                  <Textarea
+                    id="feedback-body"
+                    rows={5}
+                    placeholder="What happened? What would you love to see?"
+                    value={newItem.body}
+                    onChange={(event) => setNewItem((prev) => ({ ...prev, body: event.target.value }))}
+                  />
+                </div>
+                {formError && <p className="text-sm text-red-600">{formError}</p>}
+                <Button type="submit" disabled={creating} className="w-full md:w-auto">
+                  {creating ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <MessageSquarePlus className="w-4 h-4 mr-2" />
+                  )}
+                  Submit feedback
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card className="border border-slate-200 shadow-sm">
+            <CardHeader className="space-y-1">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle>Feedback backlog</CardTitle>
+                  <CardDescription>Browse requests and reports from the community.</CardDescription>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => loadList({ silent: true })}
+                  disabled={listLoading || refreshing}
+                >
+                  {refreshing ? <Loader2 className="w-4 h-4 animate-spin" /> : "Refresh"}
+                </Button>
+              </div>
+              <Tabs value={selectedType} onValueChange={(value) => { setSelectedType(value); setSelectedId(null); }}>
+                <TabsList className="grid grid-cols-4 gap-1 mt-4">
+                  {TYPE_TABS.map((tab) => (
+                    <TabsTrigger key={tab.value} value={tab.value} className="text-xs">
+                      {tab.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </Tabs>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {listLoading ? (
+                <div className="flex items-center gap-2 text-sm text-slate-500">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading feedback…
+                </div>
+              ) : listError ? (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {listError}
+                </div>
+              ) : filteredItems.length === 0 ? (
+                <div className="rounded-md border border-dashed border-slate-200 bg-slate-50 p-4 text-center text-sm text-slate-500">
+                  No feedback items in this category yet.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {filteredItems.map((item) => (
+                    <button
+                      type="button"
+                      key={item.id}
+                      onClick={() => setSelectedId(item.id)}
+                      className={cn(
+                        "w-full rounded-md border p-3 text-left transition",
+                        selectedId === item.id
+                          ? "border-blue-400 bg-blue-50"
+                          : "border-transparent bg-white hover:bg-slate-50"
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="space-y-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium text-slate-800">{item.title}</span>
+                            <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                              {TYPE_LABELS[item.type] || item.type}
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-slate-500 line-clamp-2">{item.body}</p>
+                        </div>
+                        <Badge className={cn("text-[10px] uppercase tracking-wide", STATUS_BADGES[item.status] || "bg-slate-100 text-slate-700") }>
+                          {STATUS_LABELS[item.status] || item.status}
+                        </Badge>
+                      </div>
+                      <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                        <span>{formatRelativeTime(item.created_at)}</span>
+                        <span className="flex items-center gap-1">
+                          <MessageCircle className="w-3 h-3" />
+                          {item.comment_count}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <ThumbsUp className="w-3 h-3" />
+                          {item.upvotes}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <ThumbsDown className="w-3 h-3" />
+                          {item.downvotes}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="lg:col-span-2">
+          <Card className="border border-slate-200 shadow-sm">
+            <CardHeader className="space-y-3">
+              <CardTitle>Feedback details</CardTitle>
+              <CardDescription>
+                Collaborate on requests, log progress, and keep everyone in the loop.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {detailLoading ? (
+                <div className="flex items-center gap-2 text-sm text-slate-500">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading details…
+                </div>
+              ) : detailError ? (
+                <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                  {detailError}
+                </div>
+              ) : !detail ? (
+                <div className="rounded-md border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
+                  Select a feedback item to see more details.
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <Badge className={cn("text-[10px] uppercase tracking-wide", STATUS_BADGES[detail.status] || "bg-slate-100 text-slate-700") }>
+                        {STATUS_LABELS[detail.status] || detail.status}
+                      </Badge>
+                      <Badge variant="outline" className="text-[10px] uppercase tracking-wide text-slate-500">
+                        {TYPE_LABELS[detail.type] || detail.type}
+                      </Badge>
+                      <span className="text-xs text-slate-500">Filed {formatRelativeTime(detail.created_at)}</span>
+                    </div>
+                    <h2 className="text-xl font-semibold text-slate-900">{detail.title}</h2>
+                    <p className="text-sm text-slate-600 whitespace-pre-line">{detail.body}</p>
+                    <p className="text-xs text-slate-500">
+                      Posted by {detail.creator_name || detail.creator_email || "someone"}
+                      {detail.creator_email ? ` • ${detail.creator_email}` : ""}
+                      {detail.created_at ? ` • ${formatFullDate(detail.created_at)}` : ""}
+                    </p>
+                  </div>
+
+                  {detail.type === "feature" && (
+                    <div className="flex flex-wrap items-center gap-3">
+                      <span className="text-sm font-medium text-slate-700">Community votes</span>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={voteBusy}
+                          onClick={() => handleVote(1)}
+                          className={cn(
+                            detail.user_vote === 1 ? "border-blue-500 bg-blue-50 text-blue-700" : "",
+                            "h-9"
+                          )}
+                        >
+                          <ThumbsUp className="w-4 h-4 mr-1" />
+                          {detail.upvotes}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={voteBusy}
+                          onClick={() => handleVote(-1)}
+                          className={cn(
+                            detail.user_vote === -1 ? "border-red-500 bg-red-50 text-red-700" : "",
+                            "h-9"
+                          )}
+                        >
+                          <ThumbsDown className="w-4 h-4 mr-1" />
+                          {detail.downvotes}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  {canUpdateStatus && (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-slate-700">Update status:</span>
+                      {STATUS_OPTIONS.map((option) => (
+                        <Button
+                          key={option.value}
+                          type="button"
+                          variant={detail.status === option.value ? "default" : "outline"}
+                          size="sm"
+                          disabled={statusUpdating}
+                          onClick={() => handleStatusChange(option.value)}
+                        >
+                          {option.label}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="space-y-4">
+                    <h3 className="text-sm font-semibold text-slate-700">
+                      Discussion ({detail.comments?.length || 0})
+                    </h3>
+                    {detail.comments && detail.comments.length > 0 ? (
+                      <div className="space-y-3">
+                        {detail.comments.map((comment) => (
+                          <div key={comment.id} className="rounded-md border border-slate-200 bg-white p-3">
+                            <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                              <span className="font-medium text-slate-700">
+                                {comment.author_name || comment.author_email || "User"}
+                              </span>
+                              {comment.author_email && (
+                                <span className="text-slate-400">{comment.author_email}</span>
+                              )}
+                              <span>{formatFullDate(comment.created_at)}</span>
+                            </div>
+                            <p className="text-sm text-slate-700 whitespace-pre-line">{comment.body}</p>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-md border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                        No comments yet. Be the first to add one.
+                      </div>
+                    )}
+
+                    <form onSubmit={handleAddComment} className="space-y-3">
+                      <Textarea
+                        rows={4}
+                        placeholder="Add a comment, share an update, or ask a follow-up question."
+                        value={commentText}
+                        onChange={(event) => setCommentText(event.target.value)}
+                      />
+                      {commentError && <p className="text-sm text-red-600">{commentError}</p>}
+                      <Button type="submit" disabled={commentSubmitting}>
+                        {commentSubmitting ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : null}
+                        Post comment
+                      </Button>
+                    </form>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SQLModel models and FastAPI routes to capture feedback items, threaded comments, and feature request voting
- surface a feedback center in the dashboard with creation, filtering, status updates, discussion, and thumbs-up/down voting
- link the new feedback center from the quick tools panel for easy access

## Testing
- pytest *(fails: worker.tasks missing create_podcast_episode callable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2ed449a483208c718d51b25530be