### PR TITLE
Gracefully handle worker task import errors in publisher service

### DIFF
--- a/tests/api/services/episodes/test_publisher_worker_import.py
+++ b/tests/api/services/episodes/test_publisher_worker_import.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+
+def _reload_publisher(monkeypatch, tasks_module):
+    module_name = "backend.api.services.episodes.publisher"
+
+    for name in list(sys.modules):
+        if name == module_name or name.startswith(f"{module_name}."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    orig_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, package=None):
+        if name == "worker.tasks":
+            from importlib.machinery import ModuleSpec
+
+            return ModuleSpec(name, loader=None)
+        return orig_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    if tasks_module is None:
+        monkeypatch.delitem(sys.modules, "worker.tasks", raising=False)
+    else:
+        monkeypatch.setitem(sys.modules, "worker.tasks", tasks_module)
+
+    return importlib.import_module(module_name)
+
+
+def test_missing_publish_task_is_reported(monkeypatch):
+    worker_stub = types.ModuleType("worker.tasks")
+    worker_stub.celery_app = object()
+
+    publisher = _reload_publisher(monkeypatch, worker_stub)
+
+    assert publisher.publish_episode_to_spreaker_task is None
+
+    with pytest.raises(HTTPException) as excinfo:
+        publisher._ensure_publish_task_available()
+
+    exc = excinfo.value
+    assert exc.status_code == 503
+    detail = exc.detail or {}
+    assert detail.get("code") == "PUBLISH_WORKER_UNAVAILABLE"
+    assert "publish_episode_to_spreaker_task missing" in (detail.get("import_error") or "")


### PR DESCRIPTION
## Summary
- guard the episode publishing service against environments where `worker.tasks` is unavailable or missing required callables, logging the root cause and surfacing it in the 503 response so the episodes router can still load
- return an explicit 503 when publish operations are attempted without a background worker and skip Celery heartbeat checks when no app is present
- add regression coverage ensuring missing publish tasks are reported instead of crashing module import

## Testing
- pytest tests/api/services/episodes/test_publisher_worker_import.py -q
- pytest tests/worker/test_tasks_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68deb293baac83209dfcb99fb5b28049