### PR TITLE
Support inline assembly execution when Celery is unavailable

### DIFF
--- a/backend/api/services/episodes/assembler.py
+++ b/backend/api/services/episodes/assembler.py
@@ -70,14 +70,14 @@ def _load_inline_executor():
     if _INLINE_EXECUTOR is not None:
         return _INLINE_EXECUTOR
 
-    if create_podcast_episode is not None:
-        _INLINE_EXECUTOR = cast(Any, create_podcast_episode)
-        return _INLINE_EXECUTOR
-
-    for module_name in (
+    module_candidates = (
+        "worker.tasks.assembly.inline",
+        "backend.worker.tasks.assembly.inline",
         "worker.tasks.assembly.orchestrator",
         "backend.worker.tasks.assembly.orchestrator",
-    ):
+    )
+
+    for module_name in module_candidates:
         try:
             module = import_module(module_name)
         except Exception:
@@ -86,6 +86,10 @@ def _load_inline_executor():
         if callable(candidate):
             _INLINE_EXECUTOR = candidate
             return _INLINE_EXECUTOR
+
+    if create_podcast_episode is not None:
+        _INLINE_EXECUTOR = cast(Any, create_podcast_episode)
+        return _INLINE_EXECUTOR
 
     return None
 

--- a/backend/worker/tasks/__init__.py
+++ b/backend/worker/tasks/__init__.py
@@ -10,7 +10,12 @@ deployments keep working.
 
 from __future__ import annotations
 
-from .app import celery_app  # backwards-compatible import path
+try:
+    from .app import celery_app  # backwards-compatible import path
+except ModuleNotFoundError:
+    celery_app = None  # type: ignore[assignment]
+except Exception:
+    celery_app = None  # type: ignore[assignment]
 
 # Prefer re-exporting from the new modular implementations
 try:  # pragma: no cover - defensive import shim

--- a/backend/worker/tasks/assembly/__init__.py
+++ b/backend/worker/tasks/assembly/__init__.py
@@ -2,39 +2,47 @@
 
 from __future__ import annotations
 
-from ..app import celery_app
+try:
+    from ..app import celery_app
+except ModuleNotFoundError:
+    celery_app = None  # type: ignore[assignment]
+except Exception:
+    celery_app = None  # type: ignore[assignment]
 
 from .orchestrator import orchestrate_create_podcast_episode
 
+if celery_app is not None:
 
-@celery_app.task(name="create_podcast_episode")
-def create_podcast_episode(
-    episode_id: str,
-    template_id: str,
-    main_content_filename: str,
-    output_filename: str,
-    tts_values: dict,
-    episode_details: dict,
-    user_id: str,
-    podcast_id: str,
-    intents: dict | None = None,
-    *,
-    skip_charge: bool = False,
-):
-    """Celery task wrapper delegating to the orchestrator helper."""
+    @celery_app.task(name="create_podcast_episode")
+    def create_podcast_episode(
+        episode_id: str,
+        template_id: str,
+        main_content_filename: str,
+        output_filename: str,
+        tts_values: dict,
+        episode_details: dict,
+        user_id: str,
+        podcast_id: str,
+        intents: dict | None = None,
+        *,
+        skip_charge: bool = False,
+    ):
+        """Celery task wrapper delegating to the orchestrator helper."""
 
-    return orchestrate_create_podcast_episode(
-        episode_id=episode_id,
-        template_id=template_id,
-        main_content_filename=main_content_filename,
-        output_filename=output_filename,
-        tts_values=tts_values,
-        episode_details=episode_details,
-        user_id=user_id,
-        podcast_id=podcast_id,
-        intents=intents,
-        skip_charge=skip_charge,
-    )
+        return orchestrate_create_podcast_episode(
+            episode_id=episode_id,
+            template_id=template_id,
+            main_content_filename=main_content_filename,
+            output_filename=output_filename,
+            tts_values=tts_values,
+            episode_details=episode_details,
+            user_id=user_id,
+            podcast_id=podcast_id,
+            intents=intents,
+            skip_charge=skip_charge,
+        )
+else:  # pragma: no cover - exercised indirectly via inline import
+    create_podcast_episode = None  # type: ignore[assignment]
 
 
 __all__ = ["create_podcast_episode", "orchestrate_create_podcast_episode"]

--- a/backend/worker/tasks/assembly/billing.py
+++ b/backend/worker/tasks/assembly/billing.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from typing import Optional
 from uuid import UUID
 
-from celery import current_task
+try:
+    from celery import current_task
+except ModuleNotFoundError:  # pragma: no cover - exercised when Celery absent
+    current_task = None  # type: ignore[assignment]
+except Exception:  # pragma: no cover - defensive import guard
+    current_task = None  # type: ignore[assignment]
 
 from api.core.paths import MEDIA_DIR
 from api.services.billing import usage as usage_svc

--- a/backend/worker/tasks/assembly/inline.py
+++ b/backend/worker/tasks/assembly/inline.py
@@ -1,0 +1,8 @@
+"""Celery-free assembly entry point for inline execution."""
+
+from __future__ import annotations
+
+from .orchestrator import orchestrate_create_podcast_episode
+
+__all__ = ["orchestrate_create_podcast_episode"]
+

--- a/backend/worker/tasks/assembly/media.py
+++ b/backend/worker/tasks/assembly/media.py
@@ -517,24 +517,29 @@ def resolve_media_context(
                 if without_scheme:
                     try:
                         bucket_name, key = without_scheme.split("/", 1)
-                    bucket_name, key = without_scheme.split("/", 1)
-                    # Decide a local filename: prefer last stem in base_stems, else from key
-                    try:
-                        local_stem = base_stems[-1] if base_stems else Path(key).stem
-                    except Exception:
-                        local_stem = Path(key).stem
-                    local_path = (PROJECT_ROOT / "transcripts") / f"{sanitize_filename(local_stem)}.json"
-                    local_path.parent.mkdir(parents=True, exist_ok=True)
-                    from infrastructure import gcs as gcs_utils  # type: ignore
+                        try:
+                            local_stem = base_stems[-1] if base_stems else Path(key).stem
+                        except Exception:
+                            local_stem = Path(key).stem
+                        local_path = (PROJECT_ROOT / "transcripts") / f"{sanitize_filename(local_stem)}.json"
+                        local_path.parent.mkdir(parents=True, exist_ok=True)
+                        from infrastructure import gcs as gcs_utils  # type: ignore
 
-                    data = gcs_utils.download_gcs_bytes(bucket_name, key)
-                    if data:
-                        local_path.write_bytes(data)
-                        if local_path.exists() and local_path.stat().st_size > 0:
-                            words_json_path = local_path
-                            logging.info("[assemble] downloaded transcript JSON from GCS to %s", str(local_path))
-                except Exception:
-                    logging.warning("[assemble] Failed to download transcript JSON from %s", gcs_json, exc_info=True)
+                        data = gcs_utils.download_gcs_bytes(bucket_name, key)
+                        if data:
+                            local_path.write_bytes(data)
+                            if local_path.exists() and local_path.stat().st_size > 0:
+                                words_json_path = local_path
+                                logging.info(
+                                    "[assemble] downloaded transcript JSON from GCS to %s",
+                                    str(local_path),
+                                )
+                    except Exception:
+                        logging.warning(
+                            "[assemble] Failed to download transcript JSON from %s",
+                            gcs_json,
+                            exc_info=True,
+                        )
         except Exception:
             pass
 

--- a/tests/api/services/episodes/test_assembler_inline.py
+++ b/tests/api/services/episodes/test_assembler_inline.py
@@ -1,0 +1,95 @@
+import builtins
+import importlib
+import sys
+from uuid import uuid4
+
+from api.models.podcast import Podcast
+from api.models.user import User
+
+
+def _reload_assembler(monkeypatch):
+    module_name = "backend.api.services.episodes.assembler"
+    for name in list(sys.modules):
+        if name == module_name or name.startswith(f"{module_name}."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    return importlib.import_module(module_name)
+
+
+def test_inline_executor_available_without_celery(monkeypatch, session):
+    def _run_without_celery():
+        with monkeypatch.context() as patcher:
+            for name in list(sys.modules):
+                if name.startswith("backend.api.services.episodes.assembler"):
+                    patcher.delitem(sys.modules, name, raising=False)
+                if name.startswith("worker.tasks"):
+                    patcher.delitem(sys.modules, name, raising=False)
+                if name.startswith("celery"):
+                    patcher.delitem(sys.modules, name, raising=False)
+
+            real_import = builtins.__import__
+
+            def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name == "celery":
+                    raise ModuleNotFoundError("No module named 'celery'")
+                return real_import(name, globals, locals, fromlist, level)
+
+            patcher.setattr(builtins, "__import__", fake_import)
+            patcher.setenv("APP_ENV", "dev")
+            patcher.delenv("CELERY_EAGER", raising=False)
+            patcher.setenv("USE_CLOUD_TASKS", "0")
+
+            assembler = _reload_assembler(patcher)
+            inline_module = importlib.import_module("backend.worker.tasks.assembly.inline")
+            worker_inline_module = importlib.import_module("worker.tasks.assembly.inline")
+
+            captured: dict[str, dict] = {}
+
+            def fake_orchestrate(**kwargs):
+                captured["kwargs"] = kwargs
+                return {"status": "inline"}
+
+            for target in (inline_module, worker_inline_module):
+                patcher.setattr(
+                    target,
+                    "orchestrate_create_podcast_episode",
+                    fake_orchestrate,
+                )
+
+            assembler._INLINE_EXECUTOR = None
+
+            assert assembler.create_podcast_episode is None
+            assert assembler._can_run_inline() is True
+
+            user = User(email="inline@example.com", hashed_password="secret")
+            session.add(user)
+            session.commit()
+            session.refresh(user)
+
+            podcast = Podcast(name="Inline Show", user_id=user.id)
+            session.add(podcast)
+            session.commit()
+            session.refresh(podcast)
+
+            template_uuid = uuid4()
+
+            result = assembler.assemble_or_queue(
+                session=session,
+                current_user=user,
+                template_id=template_uuid,
+                main_content_filename="missing.wav",
+                output_filename="output.wav",
+                tts_values={},
+                episode_details={},
+                intents=None,
+            )
+
+            return assembler, result, captured
+
+    assembler, result, captured = _run_without_celery()
+    importlib.reload(assembler)
+
+    assert result["mode"] == "fallback-inline"
+    assert result["result"] == {"status": "inline"}
+    assert "kwargs" in captured
+    assert captured["kwargs"]["skip_charge"] is True
+    assert captured["kwargs"]["episode_id"] == str(result["episode_id"])


### PR DESCRIPTION
## Summary
- add a Celery-free assembly inline entry point and guard worker package imports when Celery is missing
- update the episode assembler to prefer the inline orchestrator while hardening assembly helpers for missing Celery
- add regression coverage that exercises inline execution when Celery cannot be imported

## Testing
- pytest tests/api/services/episodes/test_assembler_inline.py

------
https://chatgpt.com/codex/tasks/task_e_68df7d1f853483208b3c280986684ea9