### PR TITLE
Add browser audio conversion toggle support

### DIFF
--- a/frontend/src/tests/testServer.ts
+++ b/frontend/src/tests/testServer.ts
@@ -1,0 +1,8 @@
+import { beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+
+export const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- add the browser audio conversion setting to the shared admin feature toggles component and persist it via the admin settings API
- keep the dashboard admin settings view in sync by storing the full settings payload and propagating updates back to the toggles
- expand the admin settings tests and supporting MSW server to cover the new switch and payload expectations

## Testing
- npm run test -- --run --coverage=false src/tests/AdminSettings.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e03b1fd8dc83209266332560362edb