### PR TITLE
Ensure AI suggestions use episode-specific transcripts

### DIFF
--- a/backend/api/routers/sections.py
+++ b/backend/api/routers/sections.py
@@ -148,7 +148,7 @@ def ai_suggest_section(
             from . import ai_suggestions as _ai
             inp.transcript_path = (
                 _ai._discover_transcript_for_episode(session, str(inp.episode_id), getattr(inp, "hint", None))
-                or _ai._discover_or_materialize_transcript(str(inp.episode_id))
+                or _ai._discover_or_materialize_transcript(str(inp.episode_id), getattr(inp, "hint", None))
             )
         except Exception:
             inp.transcript_path = None


### PR DESCRIPTION
## Summary
- scope `_discover_or_materialize_transcript` to episode- and hint-derived stems so we never reuse unrelated transcripts
- plumb the stricter lookup through the AI suggestion handlers and sections helper so missing episode transcripts trigger `409 TRANSCRIPT_NOT_READY`
- cover the regression where transcripts from other episodes were reused with a new API test

## Testing
- pytest backend/api/tests/api/test_ai_suggestions_optional_podcast.py

------
https://chatgpt.com/codex/tasks/task_e_68e0415d67988320931f99a762bf4ec6