### PR TITLE
Add marketing landing page route to SPA

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -14,6 +14,8 @@ import TermsOfUse from '@/pages/TermsOfUse.jsx';
 import Verify from '@/pages/Verify.jsx';
 import Pricing from '@/pages/Pricing.jsx';
 import PodcastWebsiteBuilder from '@/pages/PodcastWebsiteBuilder.jsx';
+import NewLanding from '@/pages/NewLanding.jsx';
+import InDevelopment from '@/pages/InDevelopment.jsx';
 import { AuthProvider } from './AuthContext.jsx';
 import { BrandProvider } from './brand/BrandContext.jsx';
 import { ComfortProvider } from './ComfortContext.jsx';
@@ -89,7 +91,9 @@ try {
 }
 
 const router = createBrowserRouter([
-  { path: '/', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
+  { path: '/', element: <NewLanding /> },
+  { path: '/app', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
+  { path: '/app/*', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
   { path: '/admin', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
   { path: '/admin/*', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
   { path: '/dashboard', element: <AppWithToasterWrapper />, errorElement: <ErrorPage /> },
@@ -104,6 +108,7 @@ const router = createBrowserRouter([
   { path: '/pricing', element: <Pricing /> },
   { path: '/subscriptions', element: <Pricing /> },
   { path: '/docs/podcast-website-builder', element: <PodcastWebsiteBuilder /> },
+  { path: '/in-development', element: <InDevelopment /> },
   // Fallback 404 for any unknown route
   { path: '*', element: <NotFound /> },
 ]);

--- a/frontend/src/pages/InDevelopment.jsx
+++ b/frontend/src/pages/InDevelopment.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Hammer, Sparkles } from 'lucide-react';
+import './new-landing.css';
+
+export default function InDevelopment() {
+  return (
+    <div className="new-landing" style={{ minHeight: '100vh', display: 'flex', alignItems: 'center' }}>
+      <div className="nl-container" style={{ textAlign: 'center', padding: '5rem 0' }}>
+        <div className="nl-pill" style={{ justifyContent: 'center', marginBottom: '1.5rem' }}>
+          <Sparkles size={16} /> New experiences incoming
+        </div>
+        <h1 className="nl-hero-title" style={{ fontSize: 'clamp(2.2rem, 4vw, 3.2rem)', marginBottom: '1rem' }}>
+          We&apos;re still building this area
+        </h1>
+        <p className="nl-lead" style={{ margin: '0 auto 2.5rem', maxWidth: '560px' }}>
+          Thanks for your interest! Our team is actively polishing this part of the product. Sign up for the free trial and
+          we&apos;ll notify you the moment it&apos;s ready.
+        </p>
+        <div className="nl-hero-actions" style={{ justifyContent: 'center' }}>
+          <Link to="/onboarding" className="nl-button" style={{ fontSize: '1rem', padding: '0.85rem 2.1rem' }}>
+            Start Free Trial
+          </Link>
+          <Link to="/" className="nl-button-outline" style={{ fontSize: '1rem', padding: '0.85rem 2.1rem' }}>
+            Back to Home
+          </Link>
+        </div>
+        <div
+          className="nl-card"
+          style={{
+            margin: '3rem auto 0',
+            maxWidth: '520px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '1.25rem',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            className="nl-card-icon"
+            style={{
+              width: '56px',
+              height: '56px',
+              background: 'hsl(var(--primary) / 0.16)',
+              color: 'hsl(var(--primary))',
+            }}
+          >
+            <Hammer size={26} />
+          </div>
+          <div style={{ textAlign: 'left' }}>
+            <p className="font-semibold">Want early access?</p>
+            <p className="nl-lead" style={{ fontSize: '0.95rem' }}>
+              Drop us a line after you onboard—we&apos;re inviting a handful of customers to try the latest tools.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewLanding.jsx
+++ b/frontend/src/pages/NewLanding.jsx
@@ -1,0 +1,490 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ArrowRight,
+  Globe,
+  Headphones,
+  Mic,
+  Play,
+  Radio,
+  Shield,
+  Sparkles,
+  TrendingUp,
+  Users,
+  Zap,
+} from 'lucide-react';
+import './new-landing.css';
+
+const heroMeta = [
+  { icon: <Sparkles size={18} />, text: 'Anyone can do this' },
+  { icon: <Zap size={18} />, text: 'Setup in 5 minutes' },
+];
+
+const pillars = [
+  {
+    title: 'Faster',
+    description: 'Record, edit, and publish in minutes. No back-and-forth with editors. No waiting days for revisions.',
+    icon: <Zap size={28} />,
+    tone: 'primary',
+  },
+  {
+    title: 'Cheaper',
+    description: 'One affordable subscription replaces expensive editors, hosting fees, and distribution services.',
+    icon: <TrendingUp size={28} />,
+    tone: 'secondary',
+  },
+  {
+    title: 'Easier',
+    description: 'So simple, your grandparents could use it. So powerful, professionals choose it. That\'s the magic.',
+    icon: <Sparkles size={28} />,
+    tone: 'accent',
+  },
+];
+
+const features = [
+  {
+    title: 'Unlimited Hosting',
+    description: 'Upload unlimited episodes with no storage limits. Your content, your way, without restrictions.',
+    icon: <Mic size={26} />,
+    tone: 'primary',
+  },
+  {
+    title: 'AI-Powered Editing',
+    description: 'Edit while you record with AI that removes mistakes, adds effects, and polishes your audio in real-time.',
+    icon: <Sparkles size={26} />,
+    tone: 'secondary',
+  },
+  {
+    title: 'Global Distribution',
+    description: 'Automatically distribute to Spotify, Apple Podcasts, Google Podcasts, and 20+ platforms.',
+    icon: <Globe size={26} />,
+    tone: 'accent',
+  },
+  {
+    title: 'Lightning Fast',
+    description: 'Global CDN ensures your episodes load instantly for listeners anywhere in the world.',
+    icon: <Zap size={26} />,
+    tone: 'primary',
+  },
+  {
+    title: 'Team Collaboration',
+    description: 'Invite team members, manage permissions, and collaborate seamlessly on your podcast.',
+    icon: <Users size={26} />,
+    tone: 'secondary',
+  },
+  {
+    title: 'Custom Player',
+    description: 'Beautiful, embeddable podcast player that matches your brand and engages listeners.',
+    icon: <Headphones size={26} />,
+    tone: 'accent',
+  },
+];
+
+const differentiators = [
+  {
+    title: 'Patent-Pending Innovation',
+    description: 'Technology you literally can\'t get anywhere else. We invented it.',
+    icon: <Shield size={24} />,
+    tone: 'primary',
+  },
+  {
+    title: 'Built For Everyone',
+    description: 'From first-timers to seasoned pros. From teens to retirees. Anyone can create here.',
+    icon: <Users size={24} />,
+    tone: 'secondary',
+  },
+  {
+    title: 'Unbeatable Value',
+    description: 'Replace your editor, hosting, and distribution services with one affordable platform.',
+    icon: <TrendingUp size={24} />,
+    tone: 'accent',
+  },
+  {
+    title: 'AI That Actually Works',
+    description: 'Not gimmicky features. Real AI that saves you hours and makes you sound professional.',
+    icon: <Sparkles size={24} />,
+    tone: 'primary',
+  },
+];
+
+const footerLinks = [
+  {
+    title: 'Product',
+    links: [
+      { label: 'Features', href: '#features' },
+      { label: 'Pricing', href: '/pricing' },
+      { label: 'FAQ', href: '/in-development' },
+    ],
+  },
+  {
+    title: 'Company',
+    links: [
+      { label: 'About', href: '/in-development' },
+      { label: 'Blog', href: '/in-development' },
+      { label: 'Contact', href: '/in-development' },
+    ],
+  },
+  {
+    title: 'Legal',
+    links: [
+      { label: 'Privacy', href: '/privacy' },
+      { label: 'Terms', href: '/terms' },
+    ],
+  },
+];
+
+const Step = ({ number, color, title, description }) => (
+  <div className="nl-step">
+    <div
+      className="nl-step-number"
+      style={{
+        borderColor: `hsl(var(--border))`,
+        background: `hsl(var(--${color}) / 0.12)`,
+        color: `hsl(var(--${color}))`,
+      }}
+    >
+      {number}
+    </div>
+    <h3>{title}</h3>
+    <p>{description}</p>
+  </div>
+);
+
+const FeatureCard = ({ title, description, icon, tone }) => (
+  <div className="nl-card">
+    <div
+      className="nl-card-icon"
+      style={{
+        background: `hsl(var(--${tone}) / 0.14)`,
+        color: `hsl(var(--${tone}))`,
+      }}
+    >
+      {icon}
+    </div>
+    <h3>{title}</h3>
+    <p>{description}</p>
+  </div>
+);
+
+const PillarCard = ({ title, description, icon, tone }) => (
+  <div className="nl-card">
+    <div
+      className="nl-card-icon"
+      style={{
+        background: `hsl(var(--${tone}) / 0.16)`,
+        color: `hsl(var(--${tone}))`,
+      }}
+    >
+      {icon}
+    </div>
+    <h3>{title}</h3>
+    <p>{description}</p>
+  </div>
+);
+
+const Differentiator = ({ title, description, icon, tone }) => (
+  <div className="flex items-start gap-4">
+    <div
+      className="nl-card-icon"
+      style={{
+        width: '48px',
+        height: '48px',
+        marginBottom: 0,
+        background: `hsl(var(--${tone}) / 0.16)`,
+        color: `hsl(var(--${tone}))`,
+      }}
+    >
+      {icon}
+    </div>
+    <div>
+      <h4 className="font-semibold text-lg mb-2">{title}</h4>
+      <p className="nl-lead text-base">{description}</p>
+    </div>
+  </div>
+);
+
+const FooterColumn = ({ title, links }) => (
+  <div>
+    <p className="nl-footer-title">{title}</p>
+    <ul className="nl-footer-links">
+      {links.map((link) => (
+        <li key={link.label}>
+          {link.href.startsWith('/') ? (
+            <Link to={link.href}>{link.label}</Link>
+          ) : (
+            <a href={link.href}>{link.label}</a>
+          )}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default function NewLanding() {
+  return (
+    <div className="new-landing">
+      <nav className="nl-nav">
+        <div className="nl-container">
+          <div className="nl-nav-inner">
+            <div className="nl-brand">
+              <span className="nl-brand-icon">
+                <Radio size={22} />
+              </span>
+              PodcastPlusPlus
+            </div>
+            <div className="nl-nav-links">
+              <a href="#features">Features</a>
+              <a href="#pricing">Pricing</a>
+              <a href="#about">About</a>
+            </div>
+            <div className="nl-nav-cta">
+              <Link to="/app" className="nl-button-outline">
+                Log In
+              </Link>
+              <Link to="/onboarding" className="nl-button">
+                Start Free Trial
+              </Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <header className="nl-hero">
+        <div className="nl-container nl-hero-grid">
+          <div>
+            <span className="nl-hero-label">
+              <Sparkles size={16} /> Patent-Pending AI Technology
+            </span>
+            <h1 className="nl-hero-title">
+              Professional Podcasting <span>For Everyone</span>
+            </h1>
+            <p className="nl-hero-description">
+              No experience needed. No technical skills required. No age limit. Just you and your voice. PodcastPlusPlus
+              makes professional podcasting so easy, it\'s faster and cheaper than hiring someone else to do it.
+            </p>
+            <div className="nl-hero-actions">
+              <Link to="/onboarding" className="nl-button">
+                Start Your Free Trial
+                <ArrowRight size={18} />
+              </Link>
+              <Link to="/in-development" className="nl-button-outline">
+                <Play size={16} /> Watch Demo
+              </Link>
+            </div>
+            <div className="nl-hero-meta">
+              {heroMeta.map(({ icon, text }) => (
+                <div className="nl-hero-meta-item" key={text}>
+                  {icon}
+                  {text}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="nl-hero-media">
+            <div className="nl-hero-frame">
+              <div className="nl-hero-placeholder">Immersive Studio Preview</div>
+              <div
+                className="nl-float-card"
+                style={{ background: 'hsla(0, 0%, 100%, 0.92)' }}
+              >
+                <div
+                  className="nl-float-icon"
+                  style={{ background: 'hsl(var(--secondary) / 0.18)', color: 'hsl(var(--secondary))' }}
+                >
+                  <TrendingUp size={22} />
+                </div>
+                <div>
+                  <p className="font-semibold text-base">Unlimited</p>
+                  <p className="text-sm text-muted-foreground">Episodes &amp; Storage</p>
+                </div>
+              </div>
+              <div
+                className="nl-float-card nl-float-card-alt"
+                style={{ background: 'hsla(0, 0%, 100%, 0.92)' }}
+              >
+                <div
+                  className="nl-float-icon"
+                  style={{ background: 'hsl(var(--accent) / 0.2)', color: 'hsl(var(--accent))' }}
+                >
+                  <Globe size={22} />
+                </div>
+                <div>
+                  <p className="font-semibold text-base">Global</p>
+                  <p className="text-sm text-muted-foreground">CDN Distribution</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="nl-section nl-section-muted" id="about">
+        <div className="nl-container">
+          <div className="nl-section-title">
+            <h2>
+              Done For You, <span>By You</span>
+            </h2>
+            <p>
+              Why pay someone else when you can do it yourself—faster, cheaper, and with complete creative control?
+              PodcastPlusPlus is so intuitive that publishing your podcast takes less time and effort than explaining it to
+              someone else.
+            </p>
+          </div>
+          <div className="nl-grid nl-grid-3">
+            {pillars.map((pillar) => (
+              <PillarCard key={pillar.title} {...pillar} />
+            ))}
+          </div>
+          <div className="nl-card" style={{ marginTop: '2.75rem' }}>
+            <div className="grid gap-6 md:grid-cols-[1.25fr_1fr] md:items-end">
+              <div>
+                <h3 className="text-2xl font-semibold mb-2">Your Voice. Your Vision. Your Control.</h3>
+                <p className="nl-lead">
+                  No middleman. No compromises. Just pure creative freedom. We built the workflow so you can focus on what you
+                  say—not how to edit it later.
+                </p>
+              </div>
+              <div className="nl-pill justify-center md:justify-end">Launch in hours, not weeks</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="nl-section" id="pricing">
+        <div className="nl-container">
+          <div className="nl-section-title">
+            <h2>
+              From Idea to Published in <span>3 Simple Steps</span>
+            </h2>
+            <p>Seriously, it\'s this easy. No technical knowledge required. No learning curve. Just start talking.</p>
+          </div>
+          <div className="nl-grid nl-grid-3 nl-steps">
+            <span className="nl-step-connector" aria-hidden="true" />
+            <Step
+              number="1"
+              color="primary"
+              title="Record"
+              description="Hit record and start talking. Our AI handles the rest—removing mistakes, enhancing audio, and creating chapters."
+            />
+            <Step
+              number="2"
+              color="secondary"
+              title="Review"
+              description="Preview your episode with AI-applied edits. Make any final tweaks with our simple, intuitive editor."
+            />
+            <Step
+              number="3"
+              color="accent"
+              title="Publish"
+              description="One click distributes your podcast to Spotify, Apple Podcasts, and 20+ platforms. You're live!"
+            />
+          </div>
+          <div className="nl-cta">
+            <Link to="/onboarding" className="nl-button">
+              Start Your First Episode Now
+              <ArrowRight size={18} />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="nl-section" id="features">
+        <div className="nl-container">
+          <div className="nl-section-title">
+            <h2>
+              Everything You Need to <span>Succeed</span>
+            </h2>
+            <p>Professional-grade tools that would normally cost thousands. All included in one simple platform.</p>
+          </div>
+          <div className="nl-grid nl-grid-3">
+            {features.map((feature) => (
+              <FeatureCard key={feature.title} {...feature} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="nl-section nl-section-alt">
+        <div className="nl-container grid gap-10 lg:grid-cols-2 lg:items-center">
+          <div>
+            <h2 className="nl-hero-title" style={{ fontSize: 'clamp(2.2rem, 4vw, 3.2rem)', marginBottom: '1.5rem' }}>
+              Why <span>PodcastPlusPlus</span>?
+            </h2>
+            <p className="nl-lead" style={{ marginBottom: '2rem' }}>
+              We've built something truly special here. Technology that doesn't exist anywhere else. A platform that makes the
+              impossible feel effortless. This is podcasting, reimagined.
+            </p>
+            <div className="grid gap-6">
+              {differentiators.map((item) => (
+                <Differentiator key={item.title} {...item} />
+              ))}
+            </div>
+          </div>
+          <div className="nl-card">
+            <h3 className="text-2xl font-semibold mb-3">“This is the future of podcasting.”</h3>
+            <p className="nl-lead">
+              What our beta testers are saying. Every workflow, every pixel, and every AI capability is designed to save you time
+              while elevating your storytelling.
+            </p>
+              <div className="nl-pill" style={{ marginTop: '1.75rem', justifyContent: 'center' }}>
+                Built with podcasters, for podcasters
+              </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="nl-section" style={{ position: 'relative', overflow: 'hidden' }}>
+        <div className="nl-container" style={{ textAlign: 'center' }}>
+          <div className="nl-pill" style={{ justifyContent: 'center', marginBottom: '1.5rem' }}>
+            Ready when you are
+          </div>
+          <h2 className="nl-hero-title" style={{ fontSize: 'clamp(2.5rem, 4vw, 3.6rem)', marginBottom: '1.25rem' }}>
+            Ready to Take Your Podcast to the Next Level?
+          </h2>
+          <p className="nl-lead" style={{ margin: '0 auto 2.25rem', maxWidth: '560px', color: 'hsl(var(--foreground) / 0.85)' }}>
+            Join the next generation of podcasters who are building their audience with PodcastPlusPlus.
+          </p>
+          <div className="nl-hero-actions" style={{ justifyContent: 'center' }}>
+            <Link to="/onboarding" className="nl-button" style={{ fontSize: '1.05rem', padding: '0.85rem 2.3rem' }}>
+              Start Your Free Trial
+              <ArrowRight size={18} />
+            </Link>
+            <Link
+              to="/in-development"
+              className="nl-button-outline"
+              style={{ fontSize: '1.05rem', padding: '0.85rem 2.3rem', borderColor: 'hsl(var(--primary) / 0.6)' }}
+            >
+              Schedule a Demo
+            </Link>
+          </div>
+          <p className="text-sm text-muted-foreground" style={{ marginTop: '1.75rem' }}>
+            14-day free trial • No credit card required • Cancel anytime
+          </p>
+        </div>
+      </section>
+
+      <footer className="nl-footer">
+        <div className="nl-container">
+          <div className="nl-footer-grid">
+            <div>
+              <div className="nl-brand" style={{ marginBottom: '1rem' }}>
+                <span className="nl-brand-icon">
+                  <Radio size={20} />
+                </span>
+                PodcastPlusPlus
+              </div>
+              <p className="nl-lead" style={{ fontSize: '0.95rem' }}>
+                Professional podcast hosting for the modern creator.
+              </p>
+            </div>
+            {footerLinks.map((column) => (
+              <FooterColumn key={column.title} {...column} />
+            ))}
+          </div>
+          <div className="nl-footer-meta">&copy; {new Date().getFullYear()} PodcastPlusPlus. All rights reserved.</div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/new-landing.css
+++ b/frontend/src/pages/new-landing.css
@@ -1,0 +1,483 @@
+.new-landing {
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 85% 0%, hsla(185, 84%, 93%, 0.6), transparent),
+    radial-gradient(120% 120% at 10% -10%, hsla(168, 69%, 92%, 0.5), transparent);
+  color: hsl(var(--foreground));
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.new-landing a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.new-landing .nl-container {
+  width: min(1200px, 94vw);
+  margin: 0 auto;
+}
+
+.nl-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: hsla(0, 0%, 100%, 0.86);
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+html.dark .nl-nav {
+  background: hsla(240, 10%, 10%, 0.85);
+}
+
+.nl-nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0;
+}
+
+.nl-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+
+.nl-brand-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  display: grid;
+  place-items: center;
+}
+
+.nl-nav-links {
+  display: none;
+  align-items: center;
+  gap: 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+}
+
+@media (min-width: 768px) {
+  .nl-nav-links {
+    display: flex;
+  }
+}
+
+.nl-nav-links a:hover {
+  color: hsl(var(--foreground));
+}
+
+.nl-nav-cta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.nl-button,
+.nl-button-outline {
+  border-radius: 999px;
+  padding: 0.5rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, color 180ms ease;
+}
+
+.nl-button {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  box-shadow: 0 12px 30px -14px hsla(185, 84%, 38%, 0.7);
+}
+
+.nl-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 38px -18px hsla(185, 84%, 38%, 0.65);
+}
+
+.nl-button-outline {
+  border: 1px solid hsl(var(--border));
+  background: transparent;
+  color: hsl(var(--foreground));
+}
+
+.nl-button-outline:hover {
+  background: hsla(0, 0%, 100%, 0.6);
+}
+
+html.dark .nl-button-outline:hover {
+  background: hsla(240, 10%, 10%, 0.6);
+}
+
+/* Hero */
+.nl-hero {
+  padding: clamp(4rem, 6vw, 6rem) 0;
+  position: relative;
+}
+
+.nl-hero-grid {
+  display: grid;
+  gap: clamp(3rem, 4vw, 4rem);
+}
+
+@media (min-width: 992px) {
+  .nl-hero-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+  }
+}
+
+.nl-hero-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  background: hsla(185, 84%, 38%, 0.1);
+  color: hsl(var(--primary));
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.nl-hero-title {
+  font-size: clamp(2.75rem, 5vw, 4.75rem);
+  line-height: 1.08;
+  font-weight: 800;
+  margin-top: 1.75rem;
+  text-wrap: balance;
+}
+
+.nl-hero-title span {
+  color: hsl(var(--primary));
+}
+
+.nl-hero-description {
+  margin-top: 1.5rem;
+  font-size: clamp(1.05rem, 1.5vw, 1.35rem);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.7;
+  text-wrap: pretty;
+}
+
+.nl-hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2.25rem;
+}
+
+@media (min-width: 640px) {
+  .nl-hero-actions {
+    flex-direction: row;
+  }
+}
+
+.nl-hero-meta {
+  display: flex;
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+  flex-wrap: wrap;
+}
+
+.nl-hero-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.nl-hero-media {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.nl-hero-frame {
+  position: relative;
+  border-radius: 26px;
+  overflow: hidden;
+  background: linear-gradient(135deg, hsla(185, 84%, 38%, 0.2), hsla(43, 100%, 51%, 0.15));
+  min-height: 320px;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 25px 60px -35px rgba(15, 163, 177, 0.65);
+}
+
+.nl-hero-frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, hsla(185, 84%, 38%, 0.15), transparent 55%);
+}
+
+.nl-hero-placeholder {
+  width: 82%;
+  max-width: 440px;
+  aspect-ratio: 4 / 3;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.85), rgba(243, 250, 255, 0.6));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: hsl(var(--primary));
+  position: relative;
+}
+
+html.dark .nl-hero-placeholder {
+  background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.9));
+  color: hsla(185, 84%, 85%, 1);
+}
+
+.nl-float-card {
+  position: absolute;
+  bottom: -18px;
+  left: -18px;
+  padding: 1.1rem 1.4rem;
+  border-radius: 18px;
+  background: hsla(0, 0%, 100%, 0.9);
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 18px 35px -30px rgba(15, 163, 177, 0.8);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nl-float-card-alt {
+  bottom: unset;
+  top: -18px;
+  left: unset;
+  right: -18px;
+}
+
+html.dark .nl-float-card {
+  background: hsla(240, 10%, 8%, 0.85);
+  color: hsl(var(--foreground));
+}
+
+.nl-float-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+}
+
+/* Sections */
+.nl-section {
+  padding: clamp(3.5rem, 6vw, 6rem) 0;
+}
+
+.nl-section-muted {
+  background: linear-gradient(135deg, hsla(185, 84%, 38%, 0.08), hsla(43, 100%, 51%, 0.06));
+}
+
+.nl-section-alt {
+  background: linear-gradient(135deg, hsla(185, 84%, 38%, 0.06), hsla(168, 69%, 92%, 0.4));
+}
+
+.nl-section-title {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+}
+
+.nl-section-title h2 {
+  font-size: clamp(2.25rem, 3.5vw, 3.75rem);
+  font-weight: 800;
+  text-wrap: balance;
+  margin-bottom: 1rem;
+}
+
+.nl-section-title span {
+  color: hsl(var(--primary));
+}
+
+.nl-section-title p {
+  color: hsl(var(--muted-foreground));
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  line-height: 1.75;
+  text-wrap: pretty;
+}
+
+.nl-grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 768px) {
+  .nl-grid-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .nl-grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.nl-card {
+  background: hsla(0, 0%, 100%, 0.92);
+  border-radius: 22px;
+  border: 1px solid hsl(var(--border));
+  padding: clamp(1.75rem, 2.2vw, 2.5rem);
+  box-shadow: 0 18px 50px -35px rgba(15, 163, 177, 0.6);
+}
+
+html.dark .nl-card {
+  background: hsla(240, 10%, 8%, 0.85);
+}
+
+.nl-card h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.9rem;
+}
+
+.nl-card p {
+  color: hsl(var(--muted-foreground));
+  line-height: 1.7;
+}
+
+.nl-card-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.nl-steps {
+  position: relative;
+}
+
+.nl-step-connector {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .nl-step-connector {
+    display: block;
+    position: absolute;
+    top: 70px;
+    width: calc(100% + 36px);
+    height: 2px;
+    background: linear-gradient(90deg, hsla(185, 84%, 38%, 0.4), hsla(43, 100%, 51%, 0.4));
+    transform: translateX(-18px);
+    z-index: 0;
+  }
+}
+
+.nl-step {
+  position: relative;
+  text-align: center;
+  z-index: 1;
+}
+
+.nl-step-number {
+  width: 80px;
+  height: 80px;
+  border-radius: 26px;
+  display: grid;
+  place-items: center;
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin: 0 auto 1.25rem;
+  border: 5px solid hsl(var(--border));
+}
+
+.nl-step h3 {
+  font-size: 1.55rem;
+  font-weight: 700;
+  margin-bottom: 0.9rem;
+}
+
+.nl-step p {
+  color: hsl(var(--muted-foreground));
+  line-height: 1.7;
+}
+
+.nl-cta {
+  text-align: center;
+  margin-top: 2.5rem;
+}
+
+.nl-highlight {
+  color: hsl(var(--primary));
+}
+
+.nl-footer {
+  background: hsla(0, 0%, 100%, 0.9);
+  border-top: 1px solid hsl(var(--border));
+  padding: 3rem 0;
+}
+
+html.dark .nl-footer {
+  background: hsla(240, 10%, 8%, 0.9);
+}
+
+.nl-footer-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .nl-footer-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.nl-footer-title {
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.nl-footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.nl-footer-links a:hover {
+  color: hsl(var(--foreground));
+}
+
+.nl-footer-meta {
+  text-align: center;
+  border-top: 1px solid hsl(var(--border));
+  padding-top: 1.5rem;
+  margin-top: 2.5rem;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.85rem;
+}
+
+/* Utility helpers */
+.nl-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: hsla(185, 84%, 38%, 0.1);
+  color: hsl(var(--primary));
+  font-weight: 600;
+}
+
+.nl-lead {
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.75;
+  text-wrap: pretty;
+}


### PR DESCRIPTION
## Summary
- add a marketing-focused NewLanding page with hero, feature, and CTA sections styled for the PodcastPlusPlus brand
- introduce reusable landing styles and an InDevelopment holding page for unfinished flows
- route the root path to the new landing experience while keeping the application available under /app and exposing the placeholder page at /in-development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ae1257b08320a72d222af9b2d61d