### PR TITLE
Enable direct GCS uploads for large media files

### DIFF
--- a/frontend/src/components/quicktools/Recorder.jsx
+++ b/frontend/src/components/quicktools/Recorder.jsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { ArrowLeft, Mic, Square, Loader2, CheckCircle } from "lucide-react";
 import { makeApi } from "@/lib/apiClient";
+import { uploadMediaDirect } from "@/lib/directUpload";
 import { useToast } from "@/hooks/use-toast";
 
 export default function Recorder({ onBack, token, onFinish, onSaved, source="A" }) {
@@ -587,13 +588,13 @@ export default function Recorder({ onBack, token, onFinish, onSaved, source="A" 
   setSavedDisplayName(filenameWithExt);
       // Build File from Blob so server receives a filename with extension
       const file = new File([audioBlob], filenameWithExt, { type: mimeType || audioBlob.type || "audio/webm" });
-      const form = new FormData();
-      form.append("files", file);
-      form.append("friendly_names", JSON.stringify([baseName]));
-      const api = makeApi(token);
-  const res = await api.raw("/api/media/upload/main_content", { method: "POST", body: form });
-  const arr = Array.isArray(res) ? res : (res && res.data ? res.data : null);
-  const first = Array.isArray(arr) ? arr[0] : null;
+      const uploaded = await uploadMediaDirect({
+        category: 'main_content',
+        file,
+        friendlyName: baseName,
+        token,
+      });
+      const first = Array.isArray(uploaded) ? uploaded[0] : null;
       const stored = first && (first.filename || first.name || first.stored_name);
       if (!stored) throw new Error("Upload response missing filename");
       setServerFilename(stored);

--- a/frontend/src/lib/directUpload.js
+++ b/frontend/src/lib/directUpload.js
@@ -1,0 +1,158 @@
+import { makeApi } from './apiClient';
+
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== 'object') return [];
+  if (Array.isArray(value.items)) return value.items;
+  if (Array.isArray(value.results)) return value.results;
+  if (Array.isArray(value.data)) return value.data;
+  if (Array.isArray(value.records)) return value.records;
+  if (Array.isArray(value.files)) return value.files;
+  return [];
+}
+
+function uploadWithXmlHttpRequest(url, file, headers = {}, { onProgress, signal, onXhrCreate } = {}) {
+  if (typeof XMLHttpRequest === 'undefined') {
+    return fetch(url, {
+      method: 'PUT',
+      headers,
+      body: file,
+    }).then((res) => {
+      if (!res.ok) {
+        throw new Error(`Upload failed with status ${res.status}`);
+      }
+      return true;
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let abortHandler;
+    try {
+      xhr.open('PUT', url);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    if (onXhrCreate && typeof onXhrCreate === 'function') {
+      try { onXhrCreate(xhr); } catch (_) { /* ignore */ }
+    }
+    if (signal) {
+      if (signal.aborted) {
+        try { xhr.abort(); } catch (_) { /* ignore */ }
+        reject(signal.reason || new DOMException('Upload aborted', 'AbortError'));
+        return;
+      }
+      abortHandler = () => {
+        try { xhr.abort(); } catch (_) { /* ignore */ }
+        reject(signal.reason || new DOMException('Upload aborted', 'AbortError'));
+      };
+      signal.addEventListener('abort', abortHandler, { once: true });
+    }
+
+    try {
+      xhr.withCredentials = false;
+    } catch (_) { /* ignore */ }
+
+    if (headers && typeof headers === 'object') {
+      Object.entries(headers).forEach(([key, value]) => {
+        if (key && value !== undefined && value !== null) {
+          try { xhr.setRequestHeader(String(key), String(value)); } catch (_) { /* ignore */ }
+        }
+      });
+    }
+
+    xhr.upload.onprogress = (event) => {
+      if (!event || typeof onProgress !== 'function') return;
+      if (!event.lengthComputable) {
+        onProgress({ loaded: event.loaded, total: event.total, percent: null });
+        return;
+      }
+      const percent = event.total > 0 ? Math.min(100, Math.round((event.loaded / event.total) * 100)) : null;
+      onProgress({ loaded: event.loaded, total: event.total, percent });
+    };
+
+    xhr.onerror = () => {
+      reject(new Error('Upload failed. Please try again.'));
+    };
+
+    xhr.onabort = () => {
+      reject(new DOMException('Upload aborted', 'AbortError'));
+    };
+
+    xhr.onload = () => {
+      if (abortHandler && signal) {
+        try { signal.removeEventListener('abort', abortHandler); } catch (_) { /* ignore */ }
+      }
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(true);
+        return;
+      }
+      const message = `Upload failed with status ${xhr.status}`;
+      reject(new Error(message));
+    };
+
+    try {
+      xhr.send(file);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+export async function uploadMediaDirect({
+  category,
+  file,
+  friendlyName,
+  token,
+  apiClient,
+  notifyWhenReady,
+  notifyEmail,
+  onProgress,
+  signal,
+  onXhrCreate,
+} = {}) {
+  if (!category) throw new Error('category is required');
+  if (!file) throw new Error('file is required');
+
+  const api = apiClient || makeApi(token);
+  const contentType = (file.type || '').trim() || 'application/octet-stream';
+
+  const presign = await api.post(`/api/media/upload/${category}/presign`, {
+    filename: file.name || 'upload',
+    content_type: contentType,
+  });
+
+  const uploadUrl = presign?.upload_url || presign?.uploadUrl;
+  const objectPath = presign?.object_path || presign?.objectPath;
+  const headers = presign?.headers || {};
+
+  if (!uploadUrl || !objectPath) {
+    throw new Error('Failed to obtain upload URL');
+  }
+
+  await uploadWithXmlHttpRequest(uploadUrl, file, headers, { onProgress, signal, onXhrCreate });
+
+  const registerPayload = {
+    uploads: [
+      {
+        object_path: objectPath,
+        friendly_name: friendlyName,
+        original_filename: file.name || friendlyName || 'upload',
+        content_type: contentType,
+        size: typeof file.size === 'number' ? file.size : undefined,
+      },
+    ],
+  };
+
+  if (notifyWhenReady !== undefined) {
+    registerPayload.notify_when_ready = !!notifyWhenReady;
+  }
+  if (notifyEmail) {
+    registerPayload.notify_email = notifyEmail;
+  }
+
+  const registered = await api.post(`/api/media/upload/${category}/register`, registerPayload);
+  return toArray(registered);
+}
+


### PR DESCRIPTION
## Summary
- add presign and register endpoints to the media upload router so large files can be staged directly in GCS without hitting Cloud Run limits
- create a shared `uploadMediaDirect` helper and switch main-content upload flows to use presigned PUT URLs
- ensure transcription watches and overwrite flows stay intact when registering already-uploaded blobs

## Testing
- pytest backend/tests -k media --maxfail=1 *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b819a3b88320af53453a5c174f71