### PR TITLE
Persist media transcript metadata across deployments

### DIFF
--- a/backend/api/models/transcription.py
+++ b/backend/api/models/transcription.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlmodel import SQLModel, Field
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, SQLModel
 
 
 class TranscriptionWatch(SQLModel, table=True):
@@ -18,4 +19,17 @@ class TranscriptionWatch(SQLModel, table=True):
     last_status: Optional[str] = None
 
 
-__all__ = ["TranscriptionWatch"]
+class MediaTranscript(SQLModel, table=True):
+    """Persist transcript metadata for uploaded media files across deployments."""
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    media_item_id: Optional[UUID] = Field(default=None, foreign_key="mediaitem.id", index=True)
+    filename: str = Field(index=True)
+    transcript_meta_json: str = Field(default="{}", description="Serialized transcript metadata for this upload")
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    __table_args__ = (UniqueConstraint("filename", name="uq_media_transcript_filename"),)
+
+
+__all__ = ["TranscriptionWatch", "MediaTranscript"]

--- a/tests/test_media_transcript_metadata.py
+++ b/tests/test_media_transcript_metadata.py
@@ -1,0 +1,86 @@
+import json
+from uuid import uuid4
+
+from sqlmodel import select
+
+from api.models.podcast import MediaCategory, MediaItem
+from api.models.transcription import MediaTranscript
+from api.models.user import User
+from api.services import transcription
+from api.services.episodes import assembler
+
+
+def _create_user(session) -> User:
+    user = User(
+        email=f"user-{uuid4().hex}@example.com",
+        hashed_password="secret",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def test_store_and_load_media_transcript_metadata(session):
+    user = _create_user(session)
+    filename = f"gs://media-bucket/{user.id}/main_content/test_file.mp3"
+
+    media_item = MediaItem(
+        friendly_name="Test Upload",
+        category=MediaCategory.main_content,
+        filename=filename,
+        user_id=user.id,
+    )
+    session.add(media_item)
+    session.commit()
+    session.refresh(media_item)
+
+    transcription._store_media_transcript_metadata(  # type: ignore[attr-defined]
+        filename,
+        stem="test_file",
+        safe_stem="test_file",
+        bucket="media-bucket",
+        key="transcripts/test_file.json",
+        gcs_uri="gs://media-bucket/transcripts/test_file.json",
+        gcs_url="https://storage.googleapis.com/media-bucket/transcripts/test_file.json",
+    )
+
+    record = session.exec(select(MediaTranscript)).first()
+    assert record is not None
+    assert record.media_item_id == media_item.id
+    stored = json.loads(record.transcript_meta_json)
+    assert stored["gcs_json"].endswith("transcripts/test_file.json")
+    assert stored["bucket_stem"] == "test_file"
+
+    loaded = transcription.load_media_transcript_metadata_for_filename(session, filename)
+    assert loaded and loaded["gcs_json"].endswith("transcripts/test_file.json")
+
+    # Variant lookup using basename should also succeed
+    basename_loaded = transcription.load_media_transcript_metadata_for_filename(
+        session, "test_file.mp3"
+    )
+    assert basename_loaded and basename_loaded.get("stem") == "test_file"
+
+
+def test_merge_transcript_metadata_preserves_existing_fields(session):
+    filename = "gs://media-bucket/someuser/main_content/merge_case.mp3"
+    meta_payload = {"gcs_json": "gs://media-bucket/transcripts/merge_case.json", "stem": "merge_case"}
+
+    session.add(
+        MediaTranscript(
+            filename=filename,
+            transcript_meta_json=json.dumps(meta_payload),
+        )
+    )
+    session.commit()
+
+    existing_meta = {
+        "transcripts": {"gcs_url": "https://existing.example/transcript.json"},
+        "other": "value",
+    }
+
+    merged = assembler._merge_transcript_metadata_from_upload(session, dict(existing_meta), filename)
+
+    assert merged["transcripts"]["gcs_url"] == "https://existing.example/transcript.json"
+    assert merged["transcripts"]["gcs_json"] == meta_payload["gcs_json"]
+    assert merged["transcript_stem"] == "merge_case"


### PR DESCRIPTION
## Summary
- add a MediaTranscript model to keep transcript metadata tied to uploaded media
- persist and reuse transcript metadata when transcription finishes and when assembling episodes
- add coverage ensuring metadata persistence and merging behave as expected

## Testing
- pytest tests/test_media_transcript_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e2b344ec8320a99903f4f9c7f147