### PR TITLE
Fix asset URLs for dashboard media previews

### DIFF
--- a/frontend/src/components/dashboard/EpisodeHistoryPreview.jsx
+++ b/frontend/src/components/dashboard/EpisodeHistoryPreview.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import { assetUrl } from '@/lib/apiClient.js';
 import { Play, Pause, CalendarClock, Trash2, Pencil, MoreHorizontal } from 'lucide-react';
 
 /**
@@ -11,6 +12,14 @@ import { Play, Pause, CalendarClock, Trash2, Pencil, MoreHorizontal } from 'luci
 export default function EpisodeHistoryPreview({ episodes, onEdit, onDelete, formatPublishAt }) {
   const [playingId, setPlayingId] = useState(null);
   const audioRefs = useRef({});
+
+  const resolveAssetUrl = (path) => {
+    if (!path || typeof path !== 'string') return path;
+    const trimmed = path.trim();
+    if (!trimmed) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.startsWith('//')) return trimmed;
+    return assetUrl(trimmed);
+  };
 
   const togglePlay = (epId) => {
     if (playingId && playingId !== epId) {
@@ -33,7 +42,7 @@ export default function EpisodeHistoryPreview({ episodes, onEdit, onDelete, form
         <h3 className="text-lg font-semibold mb-3">New Grid Concept</h3>
         <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
           {episodes.slice(0,15).map(ep => {
-            const coverUrl = ep.cover_url || `/api/episodes/${ep.id}/cover`;
+            const coverUrl = resolveAssetUrl(ep.cover_url) || resolveAssetUrl(`/api/episodes/${ep.id}/cover`);
             return (
               <div key={ep.id} className="group relative rounded-lg overflow-hidden border bg-white shadow-sm hover:shadow-md transition-shadow">
                 <div className="aspect-square bg-gray-100 relative">
@@ -74,7 +83,7 @@ export default function EpisodeHistoryPreview({ episodes, onEdit, onDelete, form
                   </div>
                   <audio
                     ref={el => { if (el) audioRefs.current[ep.id] = el; }}
-                    src={ep.playback_url || ep.stream_url || ep.final_audio_url || ''}
+                    src={resolveAssetUrl(ep.playback_url || ep.stream_url || ep.final_audio_url || '') || ''}
                     preload="none"
                     onEnded={()=> setPlayingId(id => id===ep.id ? null : id)}
                     className="hidden"
@@ -115,7 +124,7 @@ export default function EpisodeHistoryPreview({ episodes, onEdit, onDelete, form
                   </div>
                   <audio
                     ref={el => { if (el) audioRefs.current[ep.id] = el; }}
-                    src={ep.playback_url || ep.stream_url || ep.final_audio_url || ''}
+                    src={resolveAssetUrl(ep.playback_url || ep.stream_url || ep.final_audio_url || '') || ''}
                     preload="none"
                     onEnded={()=> setPlayingId(id => id===ep.id ? null : id)}
                     className="hidden"

--- a/frontend/src/components/dashboard/podcastCreatorSteps/StepAssemble.jsx
+++ b/frontend/src/components/dashboard/podcastCreatorSteps/StepAssemble.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import { assetUrl } from '@/lib/apiClient.js';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Label } from '../../ui/label';
 import { Loader2 } from 'lucide-react';
+
+const resolveAssetUrl = (path) => {
+  if (!path || typeof path !== 'string') return path;
+  const trimmed = path.trim();
+  if (!trimmed) return trimmed;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.startsWith('//')) return trimmed;
+  return assetUrl(trimmed);
+};
 
 export default function StepAssemble({
   assemblyComplete,
@@ -57,7 +66,7 @@ export default function StepAssemble({
           {assembledEpisode.final_audio_url && (
             <div className="mt-4">
               <Label>Listen to the final episode:</Label>
-              <audio controls src={assembledEpisode.final_audio_url} className="w-full mt-2">
+              <audio controls src={resolveAssetUrl(assembledEpisode.final_audio_url)} className="w-full mt-2">
                 Your browser does not support the audio element.
               </audio>
             </div>

--- a/frontend/src/components/landing-page.jsx
+++ b/frontend/src/components/landing-page.jsx
@@ -22,7 +22,7 @@ import {
 } from "lucide-react"
 import { useState, useEffect, useRef, useMemo } from "react"
 import { useAuth } from "@/AuthContext.jsx"
-import { makeApi, buildApiUrl } from "@/lib/apiClient";
+import { makeApi, buildApiUrl, assetUrl } from "@/lib/apiClient.js";
 import { useBrand } from "@/brand/BrandContext.jsx";
 import Logo from "@/components/Logo.jsx";
 import DOMPurify from "dompurify";
@@ -48,6 +48,14 @@ const buildGoogleLoginUrl = () => {
     }
   }
   return url;
+};
+
+const resolveAssetUrl = (path) => {
+  if (!path || typeof path !== "string") return path;
+  const trimmed = path.trim();
+  if (!trimmed) return trimmed;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  return assetUrl(trimmed);
 };
 
 const LoginModal = ({ onClose }) => {
@@ -829,7 +837,7 @@ export default function PodcastPlusLanding() {
                   <Card key={ep.id} className="overflow-hidden">
                     <div className="h-40 bg-gray-100">
                       {ep.cover_url ? (
-                        <img src={ep.cover_url} alt={ep.title} className="w-full h-full object-cover" />
+                        <img src={resolveAssetUrl(ep.cover_url)} alt={ep.title} className="w-full h-full object-cover" />
                       ) : (
                         <div className="h-full flex items-center justify-center text-gray-400">No Cover</div>
                       )}
@@ -839,7 +847,7 @@ export default function PodcastPlusLanding() {
                     </CardHeader>
                     <CardContent>
                       <p className="text-sm text-gray-600 line-clamp-3 mb-2">{ep.description}</p>
-                      {ep.final_audio_url && <audio controls src={ep.final_audio_url} className="w-full" />}
+                      {ep.final_audio_url && <audio controls src={resolveAssetUrl(ep.final_audio_url)} className="w-full" />}
                     </CardContent>
                   </Card>
                 ))}


### PR DESCRIPTION
## Summary
- ensure episode history components resolve cover and audio paths through the API asset helper
- use the shared asset URL helper for StepAssemble and landing page samples so relative media loads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15eba5a788320b080b5f9f459e653