### PR TITLE
Mirror cleaned audio into workspace uploads

### DIFF
--- a/backend/worker/tasks/assembly/media.py
+++ b/backend/worker/tasks/assembly/media.py
@@ -16,7 +16,7 @@ from sqlmodel import select
 from api.core import crud
 from api.core.config import settings
 from api.core.paths import APP_ROOT as APP_ROOT_DIR
-from api.core.paths import MEDIA_DIR, WS_ROOT as PROJECT_ROOT
+from api.core.paths import MEDIA_DIR, WS_ROOT as PROJECT_ROOT, CLEANED_DIR
 from api.models.podcast import Episode, MediaCategory, MediaItem
 from api.services.audio.common import sanitize_filename
 
@@ -120,10 +120,12 @@ def _resolve_media_file(name: str) -> Optional[Path]:
 
     candidates = [
         PROJECT_ROOT / "media_uploads" / base,
+        PROJECT_ROOT / "cleaned_audio" / base,
         APP_ROOT_DIR / "media_uploads" / base,
         APP_ROOT_DIR.parent / "media_uploads" / base,
         MEDIA_DIR / base,
         MEDIA_DIR / "media_uploads" / base,
+        CLEANED_DIR / base,
     ]
 
     # To support sanitized filenames (e.g., whitespace/characters replaced) and

--- a/backend/worker/tasks/assembly/transcript.py
+++ b/backend/worker/tasks/assembly/transcript.py
@@ -621,7 +621,23 @@ def prepare_transcript_context(
                     exc_info=True,
                 )
 
-            episode.working_audio_name = dest.name
+            try:
+                project_uploads_dir = PROJECT_ROOT / "media_uploads"
+                project_uploads_dir.mkdir(parents=True, exist_ok=True)
+                project_mirror_dest = project_uploads_dir / src.name
+                if dest.exists() and project_mirror_dest.resolve() != dest.resolve():
+                    shutil.copyfile(dest, project_mirror_dest)
+                    logging.info(
+                        "[assemble] Mirrored cleaned audio into WS_ROOT/media_uploads: %s",
+                        project_mirror_dest,
+                    )
+            except Exception:
+                logging.warning(
+                    "[assemble] Failed to mirror cleaned audio into WS_ROOT/media_uploads",
+                    exc_info=True,
+                )
+
+            episode.working_audio_name = Path(dest).name
             session.add(episode)
             session.commit()
         except Exception:

--- a/tests/worker/test_transcript_prepare.py
+++ b/tests/worker/test_transcript_prepare.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dirs(tmp_path, monkeypatch):
+    from backend.worker.tasks.assembly import transcript as transcript_module
+
+    media_dir = tmp_path / "media"
+    ws_root = tmp_path / "workspace"
+    media_dir.mkdir(parents=True, exist_ok=True)
+    ws_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(transcript_module, "MEDIA_DIR", media_dir)
+    monkeypatch.setattr(transcript_module, "PROJECT_ROOT", ws_root)
+
+    yield transcript_module, media_dir, ws_root
+
+
+def test_prepare_transcript_context_mirrors_cleaned_audio(tmp_path, _isolate_dirs, monkeypatch):
+    transcript_module, media_dir, ws_root = _isolate_dirs
+
+    from backend.worker.tasks.assembly.media import MediaContext
+
+    words_json = tmp_path / "words.json"
+    words_json.write_text("[]", encoding="utf-8")
+
+    audio_src = tmp_path / "input.wav"
+    audio_src.write_bytes(b"input-bytes")
+
+    cleaned_dir = tmp_path / "cleaned"
+    cleaned_dir.mkdir(parents=True, exist_ok=True)
+    engine_output = cleaned_dir / "cleaned_input.mp3"
+    engine_output.write_bytes(b"cleaned-bytes")
+
+    def _fake_run_all(**kwargs):
+        return {"final_path": str(engine_output)}
+
+    monkeypatch.setattr(transcript_module.clean_engine, "run_all", _fake_run_all)
+
+    class _Episode:
+        def __init__(self):
+            self.user_id = "user-1"
+            self.meta_json = "{}"
+            self.working_audio_name = audio_src.name
+
+    episode = _Episode()
+
+    class _User:
+        elevenlabs_api_key = None
+
+    media_context = MediaContext(
+        template=None,
+        episode=episode,
+        user=_User(),
+        cover_image_path=None,
+        cleanup_settings={},
+        preferred_tts_provider="elevenlabs",
+        base_audio_name=audio_src.name,
+        source_audio_path=audio_src,
+        base_stems=[Path(audio_src).stem],
+        search_dirs=[tmp_path],
+    )
+
+    class _Result:
+        @staticmethod
+        def all():
+            return []
+
+    class _Session:
+        def add(self, obj):
+            return None
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+        def exec(self, query):
+            return _Result()
+
+    session = _Session()
+
+    ctx = transcript_module.prepare_transcript_context(
+        session=session,
+        media_context=media_context,
+        words_json_path=words_json,
+        main_content_filename=audio_src.name,
+        output_filename="episode",
+        tts_values={},
+        user_id="user-1",
+        intents={},
+    )
+
+    assert ctx.cleaned_path == engine_output
+    assert (media_dir / engine_output.name).exists()
+    assert (media_dir / "media_uploads" / engine_output.name).exists()
+    assert (ws_root / "media_uploads" / engine_output.name).exists()
+    assert episode.working_audio_name == engine_output.name


### PR DESCRIPTION
## Summary
- Mirror cleaned audio outputs into MEDIA_DIR/media_uploads and WS_ROOT/media_uploads while preserving the basename for downstream lookups
- Allow the media resolver to fall back to cleaned_audio directories when locating engine outputs
- Cover the transcript preparation mirroring behaviour with a focused worker test

## Testing
- pytest tests/worker/test_transcript_prepare.py
- pytest tests/worker/test_media_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68e15ecd8ba08320b830940f30206f09