### PR TITLE
Fix media deletion failure when transcripts exist

### DIFF
--- a/backend/api/routers/media/write.py
+++ b/backend/api/routers/media/write.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 
 from api.core.paths import MEDIA_DIR
 from api.models.podcast import MediaItem, MediaCategory, PodcastTemplate
-from api.models.transcription import TranscriptionWatch
+from api.models.transcription import TranscriptionWatch, MediaTranscript
 from api.models.user import User
 from api.core.database import get_session
 from api.routers.auth import get_current_user
@@ -992,6 +992,13 @@ def delete_media_item(
                 file_path.unlink()
             except Exception:
                 pass
+
+    # Clean up any transcripts tied to this media item to avoid foreign key violations
+    transcripts = session.exec(
+        select(MediaTranscript).where(MediaTranscript.media_item_id == media_item.id)
+    ).all()
+    for transcript in transcripts:
+        session.delete(transcript)
 
     session.delete(media_item)
     session.commit()


### PR DESCRIPTION
## Summary
- delete any MediaTranscript rows tied to a media item before removing the media record
- add the MediaTranscript import needed for cleanup

## Testing
- pytest tests/test_media_transcript_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68e16d2148b08320b6efad9d28c0ec75