### PR TITLE
Add Spreaker season and episode numbering support

### DIFF
--- a/backend/api/routers/episodes/write.py
+++ b/backend/api/routers/episodes/write.py
@@ -275,6 +275,8 @@ def update_episode_metadata(
             send_publish_state = publish_state is not None
             send_tags = ('tags' in payload)
             send_explicit = ('is_explicit' in payload)
+            send_season = ('season_number' in payload) and getattr(ep, 'season_number', None) is not None
+            send_episode = ('episode_number' in payload) and getattr(ep, 'episode_number', None) is not None
             tags_arg = None
             if send_tags:
                 try:
@@ -295,6 +297,8 @@ def update_episode_metadata(
                 tags=tags_arg,
                 explicit=explicit_arg,
                 image_file=img_path,
+                season_number=ep.season_number if send_season else None,
+                episode_number=ep.episode_number if send_episode else None,
             )
             if not ok:
                 try:
@@ -335,6 +339,8 @@ def update_episode_metadata(
                             ("tags", send_tags),
                             ("explicit", send_explicit),
                             ("image_file", bool(img_path)),
+                            ("season_number", send_season),
+                            ("episode_number", send_episode),
                         ] if sent
                     ]
                 }

--- a/backend/api/services/publisher.py
+++ b/backend/api/services/publisher.py
@@ -258,6 +258,8 @@ class SpreakerClient:
         tags: Optional[str] = None,
         explicit: Optional[bool] = None,
         transcript_url: Optional[str] = None,
+        season_number: Optional[int] = None,
+        episode_number: Optional[int] = None,
     ) -> Tuple[bool, Any]:
         """Upload an episode to Spreaker with robust fallbacks.
 
@@ -278,6 +280,16 @@ class SpreakerClient:
             base_data["explicit"] = "true" if explicit else "false"
         if transcript_url:
             base_data["transcript_url"] = transcript_url
+        if season_number is not None:
+            try:
+                base_data["season_number"] = int(season_number)
+            except (TypeError, ValueError):
+                pass
+        if episode_number is not None:
+            try:
+                base_data["episode_number"] = int(episode_number)
+            except (TypeError, ValueError):
+                pass
 
         # Visibility variants
         vis_from_state = "PUBLIC"
@@ -376,6 +388,8 @@ class SpreakerClient:
         transcript_url: Optional[str] = None,
         debug_try_all: bool = False,
         force_all_fields: bool = False,
+        season_number: Optional[int] = None,
+        episode_number: Optional[int] = None,
     ) -> Tuple[bool, Any]:
         """Update existing episode metadata on Spreaker.
 
@@ -400,6 +414,16 @@ class SpreakerClient:
                 data["visibility"] = "PUBLIC"
         if transcript_url is not None:
             data["transcript_url"] = transcript_url
+        if season_number is not None:
+            try:
+                data["season_number"] = int(season_number)
+            except (TypeError, ValueError):
+                pass
+        if episode_number is not None:
+            try:
+                data["episode_number"] = int(episode_number)
+            except (TypeError, ValueError):
+                pass
         files = None
         fh = None
         if image_file and os.path.isfile(image_file):

--- a/backend/worker/tasks/publish.py
+++ b/backend/worker/tasks/publish.py
@@ -228,6 +228,8 @@ def publish_episode_to_spreaker_task(
             tags=tags_arg,
             explicit=explicit_arg,
             transcript_url=transcript_url,
+            season_number=getattr(episode, "season_number", None),
+            episode_number=getattr(episode, "episode_number", None),
         )
 
         if not ok:
@@ -276,7 +278,11 @@ def publish_episode_to_spreaker_task(
                 try:
                     ep_id = str(result["episode_id"])
                     ok_upd, upd_resp = client.update_episode(
-                        ep_id, publish_state="unpublished", transcript_url=transcript_url
+                        ep_id,
+                        publish_state="unpublished",
+                        transcript_url=transcript_url,
+                        season_number=getattr(episode, "season_number", None),
+                        episode_number=getattr(episode, "episode_number", None),
                     )
                     logging.info(
                         "[publish] enforced private via update ok=%s", ok_upd
@@ -314,7 +320,11 @@ def publish_episode_to_spreaker_task(
                         )
                         if not ok_img:
                             ok_upd_img, _ = client.update_episode(
-                                ep_id, image_file=image_file_path, debug_try_all=True
+                                ep_id,
+                                image_file=image_file_path,
+                                debug_try_all=True,
+                                season_number=getattr(episode, "season_number", None),
+                                episode_number=getattr(episode, "episode_number", None),
                             )
                             logging.info(
                                 "[publish] fallback image update via update_episode ok=%s",


### PR DESCRIPTION
## Summary
- include season and episode numbers when uploading or updating episodes via the Spreaker client
- send numbering metadata from the worker publish task and episode update endpoint when syncing to Spreaker

## Testing
- pytest backend/api -q *(fails: missing required environment configuration such as DB_USER, SPREAKER credentials, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e22a079d1c8320bf495da149023917