### PR TITLE
Fix asset URL generation for static resources

### DIFF
--- a/frontend/src/lib/__tests__/apiClient.test.js
+++ b/frontend/src/lib/__tests__/apiClient.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const resetEnvAndModules = () => {
+  if (typeof vi.unstubAllEnvs === 'function') {
+    vi.unstubAllEnvs();
+  }
+  vi.resetModules();
+};
+
+describe('apiClient assetUrl', () => {
+  beforeEach(() => {
+    resetEnvAndModules();
+  });
+
+  afterEach(() => {
+    resetEnvAndModules();
+  });
+
+  it('strips trailing /api for asset paths', async () => {
+    vi.stubEnv('VITE_API_BASE', 'https://example.com/api');
+    const { assetUrl } = await import('../apiClient.js');
+    expect(assetUrl('/static/foo.jpg')).toBe('https://example.com/static/foo.jpg');
+  });
+});

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -49,6 +49,14 @@ export function buildApiUrl(path) {
   if (!base) return rawPath;
 
   const trimmedBase = base.replace(/\/+$/, '');
+  const assetPrefixes = ['/static', '/media', '/storage', '/final'];
+  const isAssetPath = assetPrefixes.some((prefix) =>
+    normalizedPath === prefix ||
+    normalizedPath.startsWith(`${prefix}/`) ||
+    normalizedPath.startsWith(`${prefix}?`) ||
+    normalizedPath.startsWith(`${prefix}#`) ||
+    normalizedPath.startsWith(`${prefix}&`)
+  );
 
   const baseHandlesApi = trimmedBase.endsWith('/api');
   if (baseHandlesApi) {
@@ -63,6 +71,17 @@ export function buildApiUrl(path) {
     }
     if (normalizedPath.startsWith('/api?') || normalizedPath.startsWith('/api#') || normalizedPath.startsWith('/api&')) {
       return `${trimmedBase}${normalizedPath.slice(4)}`;
+    }
+
+    if (isAssetPath) {
+      const rootBase = trimmedBase.slice(0, -4); // strip trailing "/api"
+      if (!rootBase) {
+        return normalizedPath;
+      }
+      if (normalizedPath === '/') {
+        return rootBase;
+      }
+      return `${rootBase}${normalizedPath}`;
     }
   }
 


### PR DESCRIPTION
## Summary
- adjust the API client URL builder to strip trailing /api when serving static asset prefixes
- add a vitest covering assetUrl to ensure /static paths resolve against the API origin root

## Testing
- npx vitest run src/lib/__tests__/apiClient.test.js --coverage.enabled=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2301ef8c083209e9bba13a7e44727