### PR TITLE
Prune missing main content uploads from dashboard

### DIFF
--- a/backend/api/routers/media/read.py
+++ b/backend/api/routers/media/read.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -9,18 +10,86 @@ from sqlalchemy import text as _sa_text
 from sqlmodel import Session, select
 
 from api.core.database import get_session
-from api.core.paths import TRANSCRIPTS_DIR
+from api.core.paths import MEDIA_DIR, TRANSCRIPTS_DIR
 from api.models.podcast import MediaCategory, MediaItem
 from api.models.transcription import TranscriptionWatch
 from api.models.user import User
 from api.routers.ai_suggestions import _gather_user_sfx_entries
 from api.routers.auth import get_current_user
+from infrastructure import gcs
 from api.services.audio.transcript_io import load_transcript_json
 from api.services.intent_detection import analyze_intents, get_user_commands
 
 from .schemas import MainContentItem
 
 router = APIRouter(prefix="/media", tags=["Media Library"])
+
+
+logger = logging.getLogger(__name__)
+
+
+def _storage_presence(filename: str) -> Optional[bool]:
+    """Return True if the backing object exists, False if known missing."""
+
+    cleaned = (filename or "").strip()
+    if not cleaned:
+        return False
+
+    if cleaned.startswith("gs://"):
+        remainder = cleaned[5:]
+        bucket, _, key = remainder.partition("/")
+        if not bucket or not key:
+            return False
+        try:
+            return gcs.blob_exists(bucket, key)
+        except Exception:  # pragma: no cover - defensive guard
+            logger.debug("Failed to probe blob existence for %s", cleaned, exc_info=True)
+            return None
+
+    try:
+        path_obj = Path(cleaned)
+    except Exception:
+        path_obj = None
+
+    if path_obj is not None:
+        try:
+            if path_obj.exists():
+                return True
+        except Exception:
+            pass
+
+    candidates: List[Path] = []
+
+    for candidate_str in (cleaned,):
+        try:
+            candidates.append((MEDIA_DIR / candidate_str).resolve(strict=False))
+        except Exception:
+            pass
+
+    try:
+        base_name = path_obj.name if path_obj is not None else Path(cleaned).name
+    except Exception:
+        base_name = cleaned
+
+    for root in (MEDIA_DIR, Path("media_uploads"), Path.cwd() / "media_uploads"):
+        try:
+            candidates.append((root / base_name).resolve(strict=False))
+        except Exception:
+            continue
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            if candidate.exists():
+                return True
+        except Exception:
+            continue
+
+    return False
 
 
 @router.get("/", response_model=List[MediaItem])
@@ -185,8 +254,13 @@ async def list_main_content_uploads(
         sfx_entries = []
 
     results: List[MainContentItem] = []
+    missing_items: List[MediaItem] = []
     for item in uploads:
         filename = str(item.filename)
+        storage_state = _storage_presence(filename)
+        if storage_state is False:
+            missing_items.append(item)
+            continue
         transcript_path = _resolve_transcript_path(filename)
         ready = transcript_path.exists()
         if not ready:
@@ -228,6 +302,24 @@ async def list_main_content_uploads(
                 duration_seconds=duration,
             )
         )
+
+    if missing_items:
+        try:
+            for stale in missing_items:
+                session.delete(stale)
+            session.commit()
+            logger.info(
+                "Pruned %s missing main-content uploads for user %s",
+                len(missing_items),
+                current_user.id,
+            )
+        except Exception:
+            session.rollback()
+            logger.warning(
+                "Failed to prune missing main-content uploads for user %s",
+                current_user.id,
+                exc_info=True,
+            )
 
     return results
 

--- a/tests/test_media_main_content_cleanup.py
+++ b/tests/test_media_main_content_cleanup.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import pytest
+from sqlmodel import select
+
+from api.core.security import get_password_hash
+from api.models.podcast import MediaCategory, MediaItem
+from api.models.user import User
+from infrastructure import gcs
+
+
+def _create_user(session) -> Tuple[User, str]:
+    password = "super-secret!"
+    user = User(
+        email="cleanup-tester@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user, password
+
+
+def _auth_headers(client, email: str, password: str) -> dict[str, str]:
+    response = client.post(
+        "/api/auth/token",
+        data={"username": email, "password": password},
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.usefixtures("db_engine")
+def test_list_main_content_prunes_missing_entries(session, client, monkeypatch):
+    user, password = _create_user(session)
+
+    missing_local = MediaItem(
+        filename="does-not-exist.wav",
+        user_id=user.id,
+        category=MediaCategory.main_content,
+    )
+    missing_gcs = MediaItem(
+        filename=f"gs://media-bucket/{user.id}/main_content/missing.wav",
+        user_id=user.id,
+        category=MediaCategory.main_content,
+    )
+
+    session.add(missing_local)
+    session.add(missing_gcs)
+    session.commit()
+
+    probe_calls = []
+
+    def _fake_blob_exists(bucket: str, key: str):
+        probe_calls.append((bucket, key))
+        return False
+
+    monkeypatch.setattr(gcs, "blob_exists", _fake_blob_exists)
+
+    headers = _auth_headers(client, user.email, password)
+    response = client.get("/api/media/main-content", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    remaining = session.exec(select(MediaItem).where(MediaItem.user_id == user.id)).all()
+    assert remaining == []
+    assert probe_calls, "expected GCS existence check to run for gs:// uploads"


### PR DESCRIPTION
## Summary
- add a storage existence check when building the main content library and prune stale records
- expose a helper to probe whether a GCS blob exists with local fallbacks for development
- cover the new pruning behaviour with an API regression test

## Testing
- pytest tests/test_media_main_content_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68e236c2899083209f6c686bce39a664