### PR TITLE
Fix asset URL handling for proxied API base

### DIFF
--- a/frontend/src/lib/__tests__/apiClient.test.js
+++ b/frontend/src/lib/__tests__/apiClient.test.js
@@ -16,9 +16,16 @@ describe('apiClient assetUrl', () => {
     resetEnvAndModules();
   });
 
-  it('strips trailing /api for asset paths', async () => {
+  it('strips trailing /api for asset paths when base is absolute', async () => {
     vi.stubEnv('VITE_API_BASE', 'https://example.com/api');
     const { assetUrl } = await import('../apiClient.js');
     expect(assetUrl('/static/foo.jpg')).toBe('https://example.com/static/foo.jpg');
+  });
+
+  it('retains /api prefix for asset paths when base is relative', async () => {
+    vi.stubEnv('VITE_API_BASE', '/api');
+    const { assetUrl } = await import('../apiClient.js');
+    expect(assetUrl('/static/foo.jpg')).toBe('/api/static/foo.jpg');
+    expect(assetUrl('static/foo.jpg')).toBe('/api/static/foo.jpg');
   });
 });

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -59,6 +59,7 @@ export function buildApiUrl(path) {
   );
 
   const baseHandlesApi = trimmedBase.endsWith('/api');
+  const isAbsoluteBase = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(trimmedBase);
   if (baseHandlesApi) {
     if (normalizedPath === '/api') {
       return trimmedBase;
@@ -74,6 +75,9 @@ export function buildApiUrl(path) {
     }
 
     if (isAssetPath) {
+      if (!isAbsoluteBase) {
+        return `${trimmedBase}${normalizedPath}`;
+      }
       const rootBase = trimmedBase.slice(0, -4); // strip trailing "/api"
       if (!rootBase) {
         return normalizedPath;


### PR DESCRIPTION
## Summary
- ensure buildApiUrl keeps the /api prefix for static assets when the API base is relative
- continue stripping /api for asset URLs when targeting an absolute backend origin
- extend apiClient assetUrl tests to cover both relative and absolute base scenarios

## Testing
- pnpm vitest run src/lib/__tests__/apiClient.test.js --coverage.enabled false

------
https://chatgpt.com/codex/tasks/task_e_68e2359a1c7c8320808d84465a330ddd